### PR TITLE
fix typo to avoid panic when execute yao restore

### DIFF
--- a/model/migrate.go
+++ b/model/migrate.go
@@ -111,7 +111,7 @@ func (mod *Model) InsertValues() ([]int, []error) {
 	for _, row := range mod.MetaData.Values {
 		id, err := mod.Create(row)
 		if err != nil {
-			errs = append(errs, nil)
+			errs = append(errs, err)
 		}
 		ids = append(ids, id)
 	}

--- a/model/model.go
+++ b/model/model.go
@@ -154,7 +154,11 @@ func (mod *Model) Reload() (*Model, error) {
 }
 
 // Migrate 数据迁移
-func (mod *Model) Migrate(force bool) error {
+func (mod *Model) Migrate(force bool, opts ...MigrateOption) error {
+	options := &MigrateOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
 	if force {
 		err := mod.DropTable()
 		if err != nil {
@@ -173,17 +177,31 @@ func (mod *Model) Migrate(force bool) error {
 			return err
 		}
 
-		_, errs := mod.InsertValues()
-		if errs != nil && len(errs) > 0 {
-			for _, err := range errs {
-				log.Error("[Migrate] %s", err.Error())
+		if !options.DonotInsertValues {
+			_, errs := mod.InsertValues()
+			if errs != nil && len(errs) > 0 {
+				for _, err := range errs {
+					log.Error("[Migrate] %s", err.Error())
+				}
+				return fmt.Errorf("%d values error, please check the logs", len(errs))
 			}
-			return fmt.Errorf("%d values error, please check the logs", len(errs))
 		}
 		return nil
 	}
 
 	return mod.SaveTable()
+}
+
+type MigrateOptions struct {
+	DonotInsertValues bool `json:"donot_insert_values"`
+}
+
+type MigrateOption func(*MigrateOptions)
+
+func WithDonotInsertValues(v bool) MigrateOption {
+	return func(mo *MigrateOptions) {
+		mo.DonotInsertValues = v
+	}
 }
 
 // Select 读取已加载模型


### PR DESCRIPTION
1. fix typo gou/model/migrate.go to avoid panic when execute the yao restore.
2. add migrate option: do not insert values when migration, for in most cases I think, `yao restore` will insert the same records which contained in model dsl values, thus restore will fail.
