### PR TITLE
RAG Engine Enhancements

### DIFF
--- a/rag/driver/qdrant/engine_test.go
+++ b/rag/driver/qdrant/engine_test.go
@@ -73,7 +73,7 @@ func TestBasicOperations(t *testing.T) {
 
 	// Test document operations
 	doc := &driver.Document{
-		DocID:    "123e4567-e89b-12d3-a456-426614174000",
+		DocID:    "test-doc-123",
 		Content:  "This is a test document for Qdrant vector search.",
 		Metadata: map[string]interface{}{"type": "test", "version": 1.0},
 	}
@@ -130,8 +130,7 @@ func TestBatchOperations(t *testing.T) {
 	docs := make([]*driver.Document, 10)
 	docIDs := make([]string, 10)
 	for i := 0; i < 10; i++ {
-		// Use proper UUID format
-		docID := fmt.Sprintf("00000000-0000-0000-0000-%012d", i)
+		docID := fmt.Sprintf("test-doc-%d", i)
 		docs[i] = &driver.Document{
 			DocID:    docID,
 			Content:  fmt.Sprintf("This is test document %d", i),
@@ -222,8 +221,7 @@ func TestTaskManagement(t *testing.T) {
 	// Create a batch operation to get a task ID
 	docs := make([]*driver.Document, 5)
 	for i := 0; i < 5; i++ {
-		// Use proper UUID format
-		docID := fmt.Sprintf("00000000-0000-0000-0000-%012d", i)
+		docID := fmt.Sprintf("test-doc-%d", i)
 		docs[i] = &driver.Document{
 			DocID:   docID,
 			Content: fmt.Sprintf("Test document for task management %d", i),
@@ -317,7 +315,7 @@ func TestResourceLeaks(t *testing.T) {
 			}()
 
 			// Use proper UUID format
-			docID := fmt.Sprintf("00000000-0000-0000-0000-%012d", i)
+			docID := fmt.Sprintf("test-doc-%d", i)
 			doc := &driver.Document{
 				DocID:   docID,
 				Content: "Test document for leak detection",
@@ -423,8 +421,7 @@ func TestConcurrentOperations(t *testing.T) {
 	for i := 0; i < numOps; i++ {
 		go func(i int) {
 			defer wg.Done()
-			// Use proper UUID format
-			docID := fmt.Sprintf("00000000-0000-0000-0000-%012d", i)
+			docID := fmt.Sprintf("test-doc-concurrent-%d", i)
 			doc := &driver.Document{
 				DocID:    docID,
 				Content:  fmt.Sprintf("Concurrent test document %d", i),
@@ -556,7 +553,7 @@ func TestQdrantEngineErrors(t *testing.T) {
 
 	// Test invalid vector dimension
 	invalidDoc := &driver.Document{
-		DocID:      "00000000-0000-0000-0000-000000000001",
+		DocID:      "test-doc-invalid",
 		Content:    "Test document",
 		Embeddings: []float32{0.1, 0.2}, // Invalid dimension
 	}

--- a/rag/driver/qdrant/engine_test.go
+++ b/rag/driver/qdrant/engine_test.go
@@ -66,6 +66,15 @@ func TestBasicOperations(t *testing.T) {
 	err = engine.CreateIndex(ctx, driver.IndexConfig{Name: indexName})
 	assert.NoError(t, err)
 
+	// Test HasIndex
+	exists, err := engine.HasIndex(ctx, indexName)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+
+	exists, err = engine.HasIndex(ctx, "non_existent_index")
+	assert.NoError(t, err)
+	assert.False(t, exists)
+
 	// List indexes
 	indexes, err := engine.ListIndexes(ctx)
 	assert.NoError(t, err)
@@ -78,9 +87,19 @@ func TestBasicOperations(t *testing.T) {
 		Metadata: map[string]interface{}{"type": "test", "version": 1.0},
 	}
 
+	// Test HasDocument before indexing
+	exists, err = engine.HasDocument(ctx, indexName, doc.DocID)
+	assert.NoError(t, err)
+	assert.False(t, exists)
+
 	// Index document
 	err = engine.IndexDoc(ctx, indexName, doc)
 	assert.NoError(t, err)
+
+	// Test HasDocument after indexing
+	exists, err = engine.HasDocument(ctx, indexName, doc.DocID)
+	assert.NoError(t, err)
+	assert.True(t, exists)
 
 	// Get document
 	retrieved, err := engine.GetDocument(ctx, indexName, doc.DocID)

--- a/rag/driver/types.go
+++ b/rag/driver/types.go
@@ -94,6 +94,7 @@ type Engine interface {
 	DeleteDoc(ctx context.Context, indexName string, DocID string) error
 	DeleteBatch(ctx context.Context, indexName string, DocIDs []string) (string, error) // Returns TaskID
 	HasDocument(ctx context.Context, indexName string, DocID string) (bool, error)
+	GetMetadata(ctx context.Context, indexName string, DocID string) (map[string]interface{}, error) // Get document metadata only
 
 	// Task operations
 	GetTaskInfo(ctx context.Context, taskID string) (*TaskInfo, error)

--- a/rag/driver/types.go
+++ b/rag/driver/types.go
@@ -86,12 +86,14 @@ type Engine interface {
 	CreateIndex(ctx context.Context, config IndexConfig) error
 	DeleteIndex(ctx context.Context, name string) error
 	ListIndexes(ctx context.Context) ([]string, error)
+	HasIndex(ctx context.Context, name string) (bool, error)
 
 	// Document operations
 	IndexDoc(ctx context.Context, indexName string, doc *Document) error
 	IndexBatch(ctx context.Context, indexName string, docs []*Document) (string, error) // Returns TaskID
 	DeleteDoc(ctx context.Context, indexName string, DocID string) error
 	DeleteBatch(ctx context.Context, indexName string, DocIDs []string) (string, error) // Returns TaskID
+	HasDocument(ctx context.Context, indexName string, DocID string) (bool, error)
 
 	// Task operations
 	GetTaskInfo(ctx context.Context, taskID string) (*TaskInfo, error)

--- a/rag/rag_test.go
+++ b/rag/rag_test.go
@@ -258,6 +258,15 @@ func TestRAGIntegration(t *testing.T) {
 		assert.NoError(t, err)
 		defer engine.DeleteIndex(ctx, indexConfig.Name)
 
+		// Test HasIndex
+		exists, err := engine.HasIndex(ctx, indexConfig.Name)
+		assert.NoError(t, err)
+		assert.True(t, exists)
+
+		exists, err = engine.HasIndex(ctx, "non_existent_index")
+		assert.NoError(t, err)
+		assert.False(t, exists)
+
 		// List indexes
 		indexes, err := engine.ListIndexes(ctx)
 		assert.NoError(t, err)
@@ -271,9 +280,19 @@ func TestRAGIntegration(t *testing.T) {
 			Metadata: map[string]interface{}{"type": "test"},
 		}
 
+		// Test HasDocument before indexing
+		exists, err = engine.HasDocument(ctx, indexConfig.Name, doc.DocID)
+		assert.NoError(t, err)
+		assert.False(t, exists)
+
 		// Index document
 		err = engine.IndexDoc(ctx, indexConfig.Name, doc)
 		assert.NoError(t, err)
+
+		// Test HasDocument after indexing
+		exists, err = engine.HasDocument(ctx, indexConfig.Name, doc.DocID)
+		assert.NoError(t, err)
+		assert.True(t, exists)
 
 		// Get document
 		retrieved, err := engine.GetDocument(ctx, indexConfig.Name, doc.DocID)

--- a/rag/rag_test.go
+++ b/rag/rag_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/yaoapp/gou/rag/driver"
 )
@@ -55,7 +55,8 @@ func TestRAGIntegration(t *testing.T) {
 
 	// Test file upload
 	t.Run("file upload", func(t *testing.T) {
-		indexName := fmt.Sprintf("%s_file_%s", baseIndexName, uuid.New().String())
+		timestamp := time.Now().UnixNano()
+		indexName := fmt.Sprintf("%s_file_%d", baseIndexName, timestamp)
 		vectorizeConfig, indexConfig := getTestConfig(t, indexName)
 
 		// Create vectorizer first
@@ -201,7 +202,8 @@ func TestRAGIntegration(t *testing.T) {
 
 	// Test basic vectorization
 	t.Run("vectorization", func(t *testing.T) {
-		indexName := fmt.Sprintf("%s_vec_%s", baseIndexName, uuid.New().String())
+		timestamp := time.Now().UnixNano()
+		indexName := fmt.Sprintf("%s_vec_%d", baseIndexName, timestamp)
 		vectorizeConfig, _ := getTestConfig(t, indexName)
 
 		vectorizer, err := NewVectorizer(DriverOpenAI, vectorizeConfig)
@@ -216,7 +218,8 @@ func TestRAGIntegration(t *testing.T) {
 
 	// Test batch vectorization
 	t.Run("batch vectorization", func(t *testing.T) {
-		indexName := fmt.Sprintf("%s_batch_vec_%s", baseIndexName, uuid.New().String())
+		timestamp := time.Now().UnixNano()
+		indexName := fmt.Sprintf("%s_batch_vec_%d", baseIndexName, timestamp)
 		vectorizeConfig, _ := getTestConfig(t, indexName)
 
 		vectorizer, err := NewVectorizer(DriverOpenAI, vectorizeConfig)
@@ -238,7 +241,8 @@ func TestRAGIntegration(t *testing.T) {
 
 	// Test index operations
 	t.Run("index operations", func(t *testing.T) {
-		indexName := fmt.Sprintf("%s_ops_%s", baseIndexName, uuid.New().String())
+		timestamp := time.Now().UnixNano()
+		indexName := fmt.Sprintf("%s_ops_%d", baseIndexName, timestamp)
 		vectorizeConfig, indexConfig := getTestConfig(t, indexName)
 
 		vectorizer, err := NewVectorizer(DriverOpenAI, vectorizeConfig)
@@ -260,8 +264,9 @@ func TestRAGIntegration(t *testing.T) {
 		assert.Contains(t, indexes, indexConfig.Name)
 
 		// Test document operations
+		docID := fmt.Sprintf("test-doc-%d", time.Now().UnixNano())
 		doc := &driver.Document{
-			DocID:    uuid.New().String(), // Generate UUID
+			DocID:    docID,
 			Content:  "This is a test document for RAG integration.",
 			Metadata: map[string]interface{}{"type": "test"},
 		}
@@ -274,6 +279,7 @@ func TestRAGIntegration(t *testing.T) {
 		retrieved, err := engine.GetDocument(ctx, indexConfig.Name, doc.DocID)
 		assert.NoError(t, err)
 		assert.Equal(t, doc.Content, retrieved.Content)
+		assert.Equal(t, doc.DocID, retrieved.DocID)
 
 		// Search
 		results, err := engine.Search(ctx, indexConfig.Name, nil, driver.VectorSearchOptions{
@@ -295,7 +301,8 @@ func TestRAGIntegration(t *testing.T) {
 
 	// Test batch operations
 	t.Run("batch operations", func(t *testing.T) {
-		indexName := fmt.Sprintf("%s_batch_%s", baseIndexName, uuid.New().String())
+		timestamp := time.Now().UnixNano()
+		indexName := fmt.Sprintf("%s_batch_%d", baseIndexName, timestamp)
 		vectorizeConfig, indexConfig := getTestConfig(t, indexName)
 
 		vectorizer, err := NewVectorizer(DriverOpenAI, vectorizeConfig)
@@ -310,18 +317,15 @@ func TestRAGIntegration(t *testing.T) {
 		assert.NoError(t, err)
 		defer engine.DeleteIndex(ctx, indexConfig.Name)
 
-		// Generate UUIDs for batch documents
-		id1 := uuid.New().String()
-		id2 := uuid.New().String()
-
+		// Create test documents with meaningful IDs
 		docs := []*driver.Document{
 			{
-				DocID:    id1,
+				DocID:    fmt.Sprintf("test-doc-batch-1-%d", timestamp),
 				Content:  "First batch document",
 				Metadata: map[string]interface{}{"index": 1},
 			},
 			{
-				DocID:    id2,
+				DocID:    fmt.Sprintf("test-doc-batch-2-%d", timestamp),
 				Content:  "Second batch document",
 				Metadata: map[string]interface{}{"index": 2},
 			},
@@ -338,7 +342,7 @@ func TestRAGIntegration(t *testing.T) {
 		assert.NotNil(t, taskInfo)
 
 		// Batch delete
-		docIDs := []string{id1, id2}
+		docIDs := []string{docs[0].DocID, docs[1].DocID}
 		deleteTaskID, err := engine.DeleteBatch(ctx, indexConfig.Name, docIDs)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, deleteTaskID)

--- a/rag/rag_test.go
+++ b/rag/rag_test.go
@@ -300,6 +300,12 @@ func TestRAGIntegration(t *testing.T) {
 		assert.Equal(t, doc.Content, retrieved.Content)
 		assert.Equal(t, doc.DocID, retrieved.DocID)
 
+		// Test GetMetadata
+		metadata, err := engine.GetMetadata(ctx, indexConfig.Name, doc.DocID)
+		assert.NoError(t, err)
+		assert.NotNil(t, metadata)
+		assert.Equal(t, "test", metadata["type"])
+
 		// Search
 		results, err := engine.Search(ctx, indexConfig.Name, nil, driver.VectorSearchOptions{
 			QueryText: "test document",


### PR DESCRIPTION
## Changes
- Refactored tests to use timestamp-based document IDs instead of UUIDs for better traceability
- Added new methods to RAG engine:
  - `HasIndex()`: Check if an index exists
  - `HasDocument()`: Verify document existence
  - `GetMetadata()`: Retrieve document metadata
- Enhanced test coverage for new functionality
