### PR TITLE
Add task status retrieval and unknown status to Plan package

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -227,6 +227,15 @@ func (p *Plan) GetStatus() (Status, map[string]Status) {
 	return p.Status, taskStatuses
 }
 
+// GetTaskStatus returns the status of a specific task
+func (p *Plan) GetTaskStatus(taskID string) (Status, error) {
+	task, exists := p.Tasks[taskID]
+	if !exists {
+		return StatusUnknown, fmt.Errorf("task with ID %s not found", taskID)
+	}
+	return task.Status, nil
+}
+
 // GetTaskData returns the data associated with a specific task
 func (p *Plan) GetTaskData(taskID string) (interface{}, error) {
 	task, exists := p.Tasks[taskID]

--- a/plan/types.go
+++ b/plan/types.go
@@ -16,6 +16,7 @@ const (
 	StatusCompleted
 	StatusFailed
 	StatusDestroyed
+	StatusUnknown
 )
 
 // Signal represents control signals for tasks

--- a/runtime/v8/isolate.go
+++ b/runtime/v8/isolate.go
@@ -14,6 +14,7 @@ import (
 	httpT "github.com/yaoapp/gou/runtime/v8/objects/http"
 	jobT "github.com/yaoapp/gou/runtime/v8/objects/job"
 	logT "github.com/yaoapp/gou/runtime/v8/objects/log"
+	planT "github.com/yaoapp/gou/runtime/v8/objects/plan"
 	queryT "github.com/yaoapp/gou/runtime/v8/objects/query"
 	storeT "github.com/yaoapp/gou/runtime/v8/objects/store"
 	timeT "github.com/yaoapp/gou/runtime/v8/objects/time"
@@ -73,6 +74,7 @@ func MakeTemplate(iso *v8go.Isolate) *v8go.ObjectTemplate {
 	template.Set("FS", fsT.New().ExportFunction(iso))
 	template.Set("Job", jobT.New().ExportFunction(iso))
 	template.Set("Store", storeT.New().ExportFunction(iso))
+	template.Set("Plan", planT.New().ExportFunction(iso))
 	template.Set("Query", queryT.New().ExportFunction(iso))
 	template.Set("WebSocket", websocketT.New().ExportFunction(iso))
 	template.Set("$L", langT.ExportFunction(iso))

--- a/runtime/v8/objects/plan/plan.go
+++ b/runtime/v8/objects/plan/plan.go
@@ -1,0 +1,192 @@
+package plan
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/yaoapp/gou/plan"
+	"github.com/yaoapp/gou/runtime/v8/bridge"
+	"rogchap.com/v8go"
+)
+
+// Object Plan Object
+type Object struct {
+	id     string
+	plan   *plan.Plan
+	shared plan.SharedSpace
+	ctx    *context.Context
+	cancel context.CancelFunc
+}
+
+// New create a new Plan Object
+func New() *Object {
+	return &Object{}
+}
+
+// StringStatus convert the plan status to a string
+func StringStatus(status plan.Status) string {
+	switch status {
+	case plan.StatusRunning:
+		return "running"
+	case plan.StatusPaused:
+		return "paused"
+	case plan.StatusCompleted:
+		return "completed"
+	case plan.StatusFailed:
+		return "failed"
+	case plan.StatusDestroyed:
+		return "destroyed"
+	case plan.StatusCreated:
+		return "created"
+	case plan.StatusUnknown:
+		return "unknown"
+	default:
+		return "unknown"
+	}
+}
+
+// ExportObject Export as a FS Object
+func (obj *Object) ExportObject(iso *v8go.Isolate) *v8go.ObjectTemplate {
+	tmpl := v8go.NewObjectTemplate(iso)
+	tmpl.Set("Add", obj.add(iso))
+	tmpl.Set("Status", obj.status(iso))
+	tmpl.Set("TaskStatus", obj.taskStatus(iso))
+	return tmpl
+}
+
+// ExportFunction Export as a javascript Plan function
+// const plan = new Plan("plan-id");
+//
+//	plan.Add("task-id", 1, function(task, shared) {
+//		shared.Set("foo", "bar");
+//	});
+func (obj *Object) ExportFunction(iso *v8go.Isolate) *v8go.FunctionTemplate {
+	object := obj.ExportObject(iso)
+	tmpl := v8go.NewFunctionTemplate(iso, func(info *v8go.FunctionCallbackInfo) *v8go.Value {
+		args := info.Args()
+		if len(args) < 1 {
+			return bridge.JsException(info.Context(), "the first parameter should be a string")
+		}
+
+		if !args[0].IsString() {
+			return bridge.JsException(info.Context(), "the first parameter should be a string")
+		}
+
+		id := args[0].String()
+		this, err := object.NewInstance(info.Context())
+		if err != nil {
+			return bridge.JsException(info.Context(), fmt.Sprintf("failed to create plan object %s", err.Error()))
+		}
+
+		// Create a new plan
+		obj.id = id // Store the id
+		ctx, cancel := context.WithCancel(context.Background())
+		obj.ctx = &ctx
+		obj.cancel = cancel
+
+		shared := plan.NewMemorySharedSpace()
+		obj.shared = shared
+		obj.plan = plan.NewPlan(ctx, id, shared)
+
+		// Set the id
+		this.Set("id", id)
+		return this.Value
+	})
+	return tmpl
+}
+
+func (obj *Object) add(iso *v8go.Isolate) *v8go.FunctionTemplate {
+	return v8go.NewFunctionTemplate(iso, func(info *v8go.FunctionCallbackInfo) *v8go.Value {
+
+		args := info.Args()
+		if len(args) < 3 {
+			return bridge.JsException(info.Context(), "missing parameters")
+		}
+
+		// Validate the task id
+		if !args[0].IsString() {
+			return bridge.JsException(info.Context(), "the task id should be a string")
+		}
+
+		// Validate the order
+		if !args[1].IsNumber() {
+			return bridge.JsException(info.Context(), "the order should be a number")
+		}
+
+		// Validate the task function
+		if !args[2].IsFunction() {
+			return bridge.JsException(info.Context(), "the task function should be a function")
+		}
+
+		// Get the task id
+		taskID := args[0].String()
+
+		// Get the order
+		order := int(args[1].Int32())
+
+		// Get the task function
+		taskFn, err := args[2].AsFunction()
+		if err != nil {
+			return bridge.JsException(info.Context(), fmt.Sprintf("failed to get the task function %s", err.Error()))
+		}
+
+		// Add the task to the plan
+		obj.plan.AddTask(taskID, order, func(ctx context.Context, shared plan.SharedSpace, signals <-chan plan.Signal) error {
+			_, err := taskFn.Call(info.This())
+			if err != nil {
+				return fmt.Errorf("failed to call the task function %s", err.Error())
+			}
+			return nil
+		})
+
+		return info.This().Value
+	})
+}
+
+// Get the status of a task
+func (obj *Object) taskStatus(iso *v8go.Isolate) *v8go.FunctionTemplate {
+	return v8go.NewFunctionTemplate(iso, func(info *v8go.FunctionCallbackInfo) *v8go.Value {
+
+		args := info.Args()
+		if len(args) < 1 {
+			return bridge.JsException(info.Context(), "missing parameters")
+		}
+
+		// Validate the task id
+		if !args[0].IsString() {
+			return bridge.JsException(info.Context(), "the task id should be a string")
+		}
+
+		taskID := args[0].String()
+		status, err := obj.plan.GetTaskStatus(taskID)
+		if err != nil {
+			return bridge.JsException(info.Context(), fmt.Sprintf("failed to get the status %s", err.Error()))
+		}
+
+		output, err := bridge.JsValue(info.Context(), StringStatus(status))
+		if err != nil {
+			return bridge.JsException(info.Context(), fmt.Sprintf("failed to get the status %s", err.Error()))
+		}
+		return output
+	})
+}
+
+// Get the status of the plan and each task
+func (obj *Object) status(iso *v8go.Isolate) *v8go.FunctionTemplate {
+	return v8go.NewFunctionTemplate(iso, func(info *v8go.FunctionCallbackInfo) *v8go.Value {
+		plan, tasks := obj.plan.GetStatus()
+
+		// Convert the plan status to a string
+		tasksStatus := make(map[string]string)
+		if tasks != nil {
+			for taskID, status := range tasks {
+				tasksStatus[taskID] = StringStatus(status)
+			}
+		}
+		output, err := bridge.JsValue(info.Context(), map[string]any{"plan": StringStatus(plan), "tasks": tasksStatus})
+		if err != nil {
+			return bridge.JsException(info.Context(), fmt.Sprintf("failed to get the status %s", err.Error()))
+		}
+		return output
+	})
+}

--- a/runtime/v8/objects/plan/plan_test.go
+++ b/runtime/v8/objects/plan/plan_test.go
@@ -1,0 +1,121 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yaoapp/gou/runtime/v8/bridge"
+	"github.com/yaoapp/kun/maps"
+	"rogchap.com/v8go"
+)
+
+func TestNewPlan(t *testing.T) {
+	ctx := prepare()
+	defer close(ctx)
+
+	v, err := ctx.RunScript(`
+	function test() {
+		const plan = new Plan("test-plan");
+		return plan.id;
+	}
+	test();
+	`, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := bridge.GoValue(v, ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "test-plan", res)
+}
+
+func TestPlanAdd(t *testing.T) {
+	ctx := prepare()
+	defer close(ctx)
+
+	v, err := ctx.RunScript(`
+	function test1() {
+		const plan = new Plan("test-plan");
+		plan.Add("task-1", 1, function(task, shared) {
+			shared.Set("foo", "bar");
+		});
+		return plan.Status();
+	}
+
+	function test2() {
+		const plan = new Plan("test2-plan");
+		plan.Add("task-2", 1, function(task, shared) {
+			shared.Set("foo", "bar");
+		});
+		return plan.Status();
+	}
+
+	function test() {
+		return {
+			test1: test1(),
+			test2: test2(),
+		}
+	}
+	test();
+	`, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := bridge.GoValue(v, ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resMap, ok := res.(map[string]interface{})
+	if !ok {
+		t.Fatal("res is not a map")
+	}
+
+	dot := maps.Of(resMap).Dot()
+	assert.Equal(t, "created", dot.Get("test1.plan"))
+	assert.Equal(t, "created", dot.Get("test2.plan"))
+	assert.Equal(t, "created", dot.Get("test1.tasks.task-1"))
+	assert.Equal(t, "created", dot.Get("test2.tasks.task-2"))
+}
+
+func TestPlanTaskStatus(t *testing.T) {
+	ctx := prepare()
+	defer close(ctx)
+
+	v, err := ctx.RunScript(`
+	function test() {
+		const plan = new Plan("test-plan");
+		plan.Add("task-1", 1, function(task, shared) {
+			shared.Set("foo", "bar");
+		});
+		return plan.TaskStatus("task-1");
+	}
+	test();
+	`, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := bridge.GoValue(v, ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "created", res)
+}
+
+// close close the v8go context
+func close(ctx *v8go.Context) {
+	ctx.Isolate().Dispose()
+}
+
+// prepare prepare the v8go context
+func prepare() *v8go.Context {
+	iso := v8go.NewIsolate()
+	template := v8go.NewObjectTemplate(iso)
+	template.Set("Plan", New().ExportFunction(iso))
+	ctx := v8go.NewContext(iso, template)
+	return ctx
+}


### PR DESCRIPTION
- Introduced `GetTaskStatus` method in Plan to retrieve status of a specific task
- Added `StatusUnknown` to task status constants for handling undefined task states
- Updated V8 runtime to include Plan object in isolate template