### PR TITLE
Add Get and Set methods to Plan object in V8 runtime

### DIFF
--- a/runtime/v8/objects/plan/plan.go
+++ b/runtime/v8/objects/plan/plan.go
@@ -59,7 +59,7 @@ func DefaultTaskFn(plan_id string, task_id string, source bool, method string, a
 		return nil, fmt.Errorf("The default task function does not support passing anonymous functions, use process instead")
 	}
 
-	p, err := process.Of(method, args...)
+	p, err := process.Of(method, fnargs...)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/v8/objects/plan/plan_test.go
+++ b/runtime/v8/objects/plan/plan_test.go
@@ -176,6 +176,31 @@ func TestPlanEvents(t *testing.T) {
 	assert.Equal(t, "completed", dot.Get("tasks.task-4"))
 }
 
+func TestPlanGetSet(t *testing.T) {
+	ctx := prepare()
+	defer close(ctx)
+
+	v, err := ctx.RunScript(`
+	function test() {
+		const plan = new Plan("test-plan");
+		plan.Set("some-key", "foo");
+		value = plan.Get("some-key");
+		plan.Release();
+		return value;
+	}
+	test();
+	`, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := bridge.GoValue(v, ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "foo", res)
+}
+
 // close close the v8go context
 func close(ctx *v8go.Context) {
 	ctx.Isolate().Dispose()


### PR DESCRIPTION
- Implemented `Get()` and `Set()` methods for Plan object to store and retrieve key-value data
- Added test case to verify Plan object's data storage and retrieval functionality
- Fixed argument passing in default task function to use processed arguments