### PR TITLE
Update GitHub Actions upload artifact to v4

### DIFF
--- a/.github/workflows/pr-receive.yml
+++ b/.github/workflows/pr-receive.yml
@@ -18,7 +18,7 @@ jobs:
           mkdir -p ./pr
           echo ${{ github.event.number }} > ./pr/NR
           echo ${{ github.event.pull_request.head.sha }} > ./pr/SHA
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: pr
           path: pr/


### PR DESCRIPTION
- Upgraded actions/upload-artifact from v3 to v4
- Minimal change to improve GitHub Actions workflow compatibility