### PR TITLE
Refactor SharedSpace methods and improve error handling in V8 runtime

### DIFF
--- a/plan/shared.go
+++ b/plan/shared.go
@@ -31,7 +31,7 @@ func (m *MemorySharedSpace) Set(key string, value interface{}) error {
 	m.subMu.RLock()
 	if callbacks, exists := m.subscribers[key]; exists {
 		for _, callback := range callbacks {
-			go callback(key, value)
+			callback(key, value)
 		}
 	}
 	m.subMu.RUnlock()
@@ -61,16 +61,15 @@ func (m *MemorySharedSpace) Delete(key string) error {
 	m.subMu.RLock()
 	if callbacks, exists := m.subscribers[key]; exists {
 		for _, callback := range callbacks {
-			go callback(key, nil)
+			callback(key, nil)
 		}
 	}
 	m.subMu.RUnlock()
-
 	return nil
 }
 
-// Clear removes all values from the shared space
-func (m *MemorySharedSpace) Clear() error {
+// ClearNotify removes all values from the shared space and notifies subscribers
+func (m *MemorySharedSpace) ClearNotify() error {
 	m.mu.Lock()
 	m.data = make(map[string]interface{})
 	m.mu.Unlock()
@@ -83,7 +82,14 @@ func (m *MemorySharedSpace) Clear() error {
 		}
 	}
 	m.subMu.RUnlock()
+	return nil
+}
 
+// Clear removes all values from the shared space
+func (m *MemorySharedSpace) Clear() error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	m.data = make(map[string]interface{})
 	return nil
 }
 

--- a/plan/types.go
+++ b/plan/types.go
@@ -92,6 +92,9 @@ type SharedSpace interface {
 	// Clear removes all values from the shared space
 	Clear() error
 
+	// ClearNotify removes all values from the shared space and notifies subscribers
+	ClearNotify() error
+
 	// Subscribe subscribes to changes in the shared space
 	Subscribe(key string, callback func(key string, value interface{})) error
 

--- a/runtime/v8/objects/plan/plan.go
+++ b/runtime/v8/objects/plan/plan.go
@@ -3,6 +3,7 @@ package plan
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/fatih/color"
@@ -492,6 +493,12 @@ func (obj *Object) get(iso *v8go.Isolate) *v8go.FunctionTemplate {
 		instance := val.(*Instance)
 		value, err := instance.shared.Get(key)
 		if err != nil {
+
+			// If the key is not found, return null
+			if strings.Contains(err.Error(), "not found") {
+				return v8go.Null(info.Context().Isolate())
+			}
+
 			return bridge.JsException(info.Context(), fmt.Sprintf("failed to get the value %s", err.Error()))
 		}
 


### PR DESCRIPTION
- Modified `Set` and `Delete` methods to remove goroutine calls for synchronous callbacks
- Added `ClearNotify` method to separate clearing with and without subscriber notification
- Updated `Clear` method to use read lock and create a new map
- Enhanced Plan object's `get` method to return null for "not found" errors in V8 runtime