### PR TITLE
Update Go version in CI workflows to 1.24

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -55,7 +55,7 @@ jobs:
 
     strategy:
       matrix:
-        go: [1.23.0]
+        go: [1.24]
         db: [MySQL8.0, SQLite3]
         redis: [4, 5, 6]
         mongo: ["6.0"]

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -57,7 +57,7 @@ jobs:
 
     strategy:
       matrix:
-        go: [1.23.0]
+        go: [1.24]
         db: [MySQL8.0, SQLite3]
         redis: [4, 5, 6]
         mongo: ["6.0"]


### PR DESCRIPTION
- Changed the Go version from 1.23.0 to 1.24 in both `pr-test.yml` and `unit-test.yml` workflows to ensure compatibility with the latest features and improvements.