### PR TITLE
Update HTTP transport timeouts for improved performance

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -56,9 +56,9 @@ func getTransport(isHTTPS bool, proxy string) *http.Transport {
 		IdleConnTimeout:     30 * time.Second, // Close idle connections after 30s
 		DisableKeepAlives:   false,            // Enable keep-alives for performance
 		// Additional production settings
-		TLSHandshakeTimeout:   10 * time.Second,
-		ResponseHeaderTimeout: 10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
+		TLSHandshakeTimeout:   30 * time.Second,
+		ResponseHeaderTimeout: 300 * time.Second,
+		ExpectContinueTimeout: 30 * time.Second,
 	}
 
 	if isHTTPS {

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -1505,9 +1505,9 @@ func TestProxyConfiguration(t *testing.T) {
 			assert.Equal(t, 100, transport.MaxIdleConns, "MaxIdleConns should be 100")
 			assert.Equal(t, 10, transport.MaxIdleConnsPerHost, "MaxIdleConnsPerHost should be 10")
 			assert.Equal(t, 30*time.Second, transport.IdleConnTimeout, "IdleConnTimeout should be 30s")
-			assert.Equal(t, 10*time.Second, transport.TLSHandshakeTimeout, "TLSHandshakeTimeout should be 10s")
-			assert.Equal(t, 10*time.Second, transport.ResponseHeaderTimeout, "ResponseHeaderTimeout should be 10s")
-			assert.Equal(t, 1*time.Second, transport.ExpectContinueTimeout, "ExpectContinueTimeout should be 1s")
+			assert.Equal(t, 30*time.Second, transport.TLSHandshakeTimeout, "TLSHandshakeTimeout should be 30s")
+			assert.Equal(t, 300*time.Second, transport.ResponseHeaderTimeout, "ResponseHeaderTimeout should be 300s")
+			assert.Equal(t, 30*time.Second, transport.ExpectContinueTimeout, "ExpectContinueTimeout should be 30s")
 		})
 	}
 }


### PR DESCRIPTION
- Increased TLSHandshakeTimeout from 10s to 30s to accommodate slower connections.
- Extended ResponseHeaderTimeout from 10s to 300s to handle longer response times.
- Adjusted ExpectContinueTimeout from 1s to 30s for better handling of client expectations during HTTP requests.
- Updated corresponding test assertions to reflect these new timeout values.