### PR TITLE
Refactor UTF-8 test cases for consistency

### DIFF
--- a/graphrag/converter/utf8_test.go
+++ b/graphrag/converter/utf8_test.go
@@ -926,8 +926,8 @@ func TestUTF8_All_Internal_Methods_Coverage(t *testing.T) {
 	testCases := [][]byte{
 		[]byte("Hello"),
 		[]byte("你好"),
-		[]byte{0xFF, 0xFE, 0xFD}, // Invalid UTF-8
-		[]byte{},                 // Empty
+		{0xFF, 0xFE, 0xFD}, // Invalid UTF-8
+		{},                 // Empty
 	}
 
 	for i, testCase := range testCases {
@@ -951,8 +951,8 @@ func TestUTF8_All_Internal_Methods_Coverage(t *testing.T) {
 	// Test chunkToUTF8 with edge cases
 	chunkTestCases := [][]byte{
 		[]byte("Normal text"),
-		[]byte{0xC0, 0x80}, // Invalid UTF-8 sequence
-		[]byte{},           // Empty
+		{0xC0, 0x80}, // Invalid UTF-8 sequence
+		{},           // Empty
 	}
 
 	for i, testCase := range chunkTestCases {


### PR DESCRIPTION
- Updated test cases in utf8_test.go to use shorthand byte slice notation for invalid UTF-8 sequences and empty slices, improving readability and consistency across tests.