### PR TITLE
Refactor conversion methods to return structured results with metadata

### DIFF
--- a/graphrag/types/interfaces.go
+++ b/graphrag/types/interfaces.go
@@ -194,8 +194,8 @@ type GraphRag interface {
 // Converter converts PDFs, Word documents, video, audio, etc. into plain text
 // and normalizes text encoding to UTF-8, providing progress via optional callbacks.
 type Converter interface {
-	Convert(ctx context.Context, file string, callback ...ConverterProgress) (string, error)                // Convert a file to plain text
-	ConvertStream(ctx context.Context, stream io.ReadSeeker, callback ...ConverterProgress) (string, error) // Convert a stream to plain text
+	Convert(ctx context.Context, file string, callback ...ConverterProgress) (*ConvertResult, error)                // Convert a file to plain text with metadata
+	ConvertStream(ctx context.Context, stream io.ReadSeeker, callback ...ConverterProgress) (*ConvertResult, error) // Convert a stream to plain text with metadata
 }
 
 // Searcher interface is used to search for chunks

--- a/graphrag/types/types.go
+++ b/graphrag/types/types.go
@@ -1788,6 +1788,12 @@ const (
 	ConverterStatusPending ConverterStatus = "pending"
 )
 
+// ConvertResult represents the result of a document conversion operation
+type ConvertResult struct {
+	Text     string                 `json:"text"`     // Converted text content
+	Metadata map[string]interface{} `json:"metadata"` // Additional metadata from conversion (page mappings, structure info, etc.)
+}
+
 // SearcherStatus represents the status of the search
 type SearcherStatus string
 


### PR DESCRIPTION
- Updated the Convert and ConvertStream methods in both UTF-8 and Vision converters to return a new ConvertResult type, encapsulating converted text and associated metadata.
- Adjusted test cases to validate the new result structure, ensuring proper handling of nil results and empty text scenarios.
- Enhanced logging to include metadata details during conversion processes, improving traceability and debugging capabilities.