### PR TITLE
Update Makefile to include 'office' in test folder selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ VETPACKAGES ?= $(shell $(GO) list ./... | grep -v /examples/)
 GOFILES := $(shell find . -name "*.go")
 
 # ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-TESTFOLDER := $(shell $(GO) list ./... | grep -E 'api|server/http|runtime|process|widget|ffmpeg|graphrag|model|plan|schema|lang|query|task|schedule|flow|session|store|fs|http|encoding|ssl|plugin|connector|wasm|websocket$|v8|application|diff' | grep -v -E 'wamr|socket')
+TESTFOLDER := $(shell $(GO) list ./... | grep -E 'api|server/http|runtime|process|widget|ffmpeg|office|graphrag|model|plan|schema|lang|query|task|schedule|flow|session|store|fs|http|encoding|ssl|plugin|connector|wasm|websocket$|v8|application|diff' | grep -v -E 'wamr|socket')
 TESTTAGS ?= ""
 
 .PHONY: test


### PR DESCRIPTION
- Modified the TESTFOLDER variable in the Makefile to include 'office' in the list of packages for testing.
- This change ensures that tests related to the 'office' package are executed during the testing process.