### PR TITLE
Implement initialization result handling in MCP client

### DIFF
--- a/mcp/client/client.go
+++ b/mcp/client/client.go
@@ -12,6 +12,7 @@ import (
 type Client struct {
 	DSL *types.ClientDSL
 	goclient.MCPClient
+	InitResult *types.InitializeResponse // Store the initialization result
 }
 
 // New create a new MCP Client (without establishing connection)
@@ -41,8 +42,9 @@ func New(dsl *types.ClientDSL) (*Client, error) {
 
 	// Create client without establishing connection
 	client := &Client{
-		DSL:       dsl,
-		MCPClient: nil, // Will be created when Connect() is called
+		DSL:        dsl,
+		MCPClient:  nil, // Will be created when Connect() is called
+		InitResult: nil, // Will be set when Initialize() is called
 	}
 
 	return client, nil

--- a/mcp/client/connection.go
+++ b/mcp/client/connection.go
@@ -141,7 +141,8 @@ func (c *Client) Disconnect(ctx context.Context) error {
 	}
 
 	err := c.MCPClient.Close()
-	c.MCPClient = nil // Clear the client reference
+	c.MCPClient = nil  // Clear the client reference
+	c.InitResult = nil // Clear the initialization result
 	return err
 }
 
@@ -154,6 +155,11 @@ func (c *Client) IsConnected() bool {
 func (c *Client) State() types.ConnectionState {
 	if c.MCPClient == nil {
 		return types.StateDisconnected
+	}
+
+	// Check if initialized
+	if c.InitResult != nil {
+		return types.StateInitialized
 	}
 
 	return types.StateConnected

--- a/mcp/client/initialization.go
+++ b/mcp/client/initialization.go
@@ -46,6 +46,9 @@ func (c *Client) Initialize(ctx context.Context) (*types.InitializeResponse, err
 		Capabilities: convertServerCapabilities(result.Capabilities),
 	}
 
+	// Store the initialization result in the client
+	c.InitResult = response
+
 	return response, nil
 }
 
@@ -123,4 +126,14 @@ func convertClientCapabilities(caps types.ClientCapabilities) mcp.ClientCapabili
 	}
 
 	return result
+}
+
+// GetInitResult returns the stored initialization result
+func (c *Client) GetInitResult() *types.InitializeResponse {
+	return c.InitResult
+}
+
+// IsInitialized checks if the client has been initialized
+func (c *Client) IsInitialized() bool {
+	return c.InitResult != nil
 }

--- a/mcp/client/transport.go
+++ b/mcp/client/transport.go
@@ -24,5 +24,8 @@ func (c *Client) Close() error {
 		return fmt.Errorf("MCP client not initialized")
 	}
 
-	return c.MCPClient.Close()
+	err := c.MCPClient.Close()
+	c.MCPClient = nil  // Clear the client reference
+	c.InitResult = nil // Clear the initialization result
+	return err
 }

--- a/mcp/client/utils_tests.go
+++ b/mcp/client/utils_tests.go
@@ -181,6 +181,31 @@ func assertClientState(t *testing.T, client *Client, expectedConnected bool, exp
 	if client.State() != expectedState {
 		t.Errorf("Expected State() = %v, got %v", expectedState, client.State())
 	}
+
+	// Additional checks for initialization state
+	switch expectedState {
+	case types.StateInitialized:
+		if !client.IsInitialized() {
+			t.Errorf("Expected IsInitialized() = true for state %v", expectedState)
+		}
+		if client.GetInitResult() == nil {
+			t.Errorf("Expected GetInitResult() to be non-nil for state %v", expectedState)
+		}
+	case types.StateConnected:
+		if client.IsInitialized() {
+			t.Errorf("Expected IsInitialized() = false for state %v", expectedState)
+		}
+		if client.GetInitResult() != nil {
+			t.Errorf("Expected GetInitResult() to be nil for state %v", expectedState)
+		}
+	case types.StateDisconnected:
+		if client.IsInitialized() {
+			t.Errorf("Expected IsInitialized() = false for state %v", expectedState)
+		}
+		if client.GetInitResult() != nil {
+			t.Errorf("Expected GetInitResult() to be nil for state %v", expectedState)
+		}
+	}
 }
 
 // logTestInfo logs test information for debugging


### PR DESCRIPTION
- Added InitResult field to the Client struct to store the initialization response.
- Enhanced the Initialize method to store the result upon successful initialization.
- Updated Disconnect and Close methods to clear the initialization result.
- Introduced IsInitialized and GetInitResult methods for better state management.
- Expanded tests to verify initialization result storage and state transitions during connection lifecycle.