### PR TITLE
Update CI workflows to streamline installation of PDF tools

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -260,15 +260,14 @@ jobs:
 
       - name: Install pdftoppm, mutool, imagemagick
         run: |
-          sudo apt install poppler-utils  # for pdftoppm
-          sudo apt install mupdf-tools    # for mutool
-          sudo apt install imagemagick    # for convert
+          sudo apt update
+          sudo apt install -y poppler-utils mupdf-tools imagemagick
 
       - name: Test pdftoppm, mutool, imagemagick
         run: |
           pdftoppm -v
           mutool -v
-          magick -version
+          convert -version
 
       - name: Setup Go Tools
         run: |

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -207,15 +207,14 @@ jobs:
 
       - name: Install pdftoppm, mutool, imagemagick
         run: |
-          sudo apt install poppler-utils  # for pdftoppm
-          sudo apt install mupdf-tools    # for mutool
-          sudo apt install imagemagick    # for convert
+          sudo apt update
+          sudo apt install -y poppler-utils mupdf-tools imagemagick
 
       - name: Test pdftoppm, mutool, imagemagick
         run: |
           pdftoppm -v
           mutool -v
-          magick -version
+          convert -version
 
       - name: Setup Go Tools
         run: |


### PR DESCRIPTION
- Consolidated installation commands for pdftoppm, mutool, and imagemagick into a single line for efficiency.
- Updated version checking command for imagemagick from 'magick -version' to 'convert -version' for consistency across workflows.