### PR TITLE
feat: add Info method to Application interface and implement in Disk …

### DIFF
--- a/application/disk/disk.go
+++ b/application/disk/disk.go
@@ -65,6 +65,15 @@ func (disk *Disk) Glob(pattern string) ([]string, error) {
 	return matches, nil
 }
 
+// Info the file info
+func (disk *Disk) Info(name string) (os.FileInfo, error) {
+	file, err := disk.abs(name)
+	if err != nil {
+		return nil, err
+	}
+	return os.Stat(file)
+}
+
 // Walk traverse folders and read file contents
 func (disk *Disk) Walk(root string, handler func(root, file string, isdir bool) error, patterns ...string) error {
 	rootAbs, err := disk.abs(root)

--- a/application/types.go
+++ b/application/types.go
@@ -1,6 +1,9 @@
 package application
 
-import "net/http"
+import (
+	"net/http"
+	"os"
+)
 
 // Application the application interface
 type Application interface {
@@ -9,6 +12,7 @@ type Application interface {
 	Write(name string, content []byte) error
 	Remove(name string) error
 	Exists(name string) (bool, error)
+	Info(name string) (os.FileInfo, error)
 	Watch(handler func(event string, name string), interrupt chan uint8) error
 	Glob(pattern string) (matches []string, err error)
 

--- a/application/yaz/fs.go
+++ b/application/yaz/fs.go
@@ -31,6 +31,11 @@ func (yaz *Yaz) FS(root string) http.FileSystem {
 	return Dir{path: filepath.Join(yaz.root, root), cipher: yaz.cipher}
 }
 
+// Info the file info
+func (yaz *Yaz) Info(name string) (os.FileInfo, error) {
+	return os.Stat(filepath.Join(yaz.root, name))
+}
+
 // Open implements FileSystem using os.Open, opening files for reading rooted
 func (dir Dir) Open(name string) (http.File, error) {
 


### PR DESCRIPTION
…and Yaz types

- Introduced the `Info` method to the `Application` interface for retrieving file information.
- Implemented the `Info` method in the `Disk` type to return file stats using `os.Stat`.
- Added the `Info` method in the `Yaz` type to provide file information based on the root path.
- Enhanced code organization by grouping imports in `types.go` for better readability.