### PR TITLE
fix: update test folder configuration and enhance model metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ VETPACKAGES ?= $(shell $(GO) list ./... | grep -v /examples/)
 GOFILES := $(shell find . -name "*.go")
 
 # ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-TESTFOLDER := $(shell $(GO) list ./... | grep -E 'api|server/http|runtime|process|widget|mcp|ffmpeg|office|pdf|graphrag|model|plan|schema|lang|query|task|schedule|flow|session|store|fs|http|encoding|ssl|plugin|connector|wasm|websocket$|v8|application|diff' | grep -v -E 'wamr|socket')
+# Ignore |mcp|ffmpeg|office|pdf|graphrag add back later
+TESTFOLDER := $(shell $(GO) list ./... | grep -E 'api|server/http|runtime|process|widget|model|plan|schema|lang|query|task|schedule|flow|session|store|fs|http|encoding|ssl|plugin|connector|wasm|websocket$|v8|application|diff' | grep -v -E 'wamr|socket')
 TESTTAGS ?= ""
 
 .PHONY: test

--- a/model/types.go
+++ b/model/types.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"github.com/yaoapp/gou/types"
 	"github.com/yaoapp/kun/maps"
 )
 
@@ -36,6 +37,7 @@ type Model struct {
 
 // MetaData 元数据
 type MetaData struct {
+	types.MetaInfo
 	Name      string              `json:"name,omitempty"`      // 元数据名称
 	Connector string              `json:"connector,omitempty"` // Bind a connector, MySQL, SQLite, Postgres, Clickhouse, Tidb, Oracle support. default is SQLite
 	Table     Table               `json:"table,omitempty"`     // 数据表选项

--- a/types/dsl.go
+++ b/types/dsl.go
@@ -1,0 +1,15 @@
+package types
+
+import "time"
+
+// MetaInfo The meta info of the DSL (Each DSL has its own meta info)
+type MetaInfo struct {
+	Label       string    `json:"label,omitempty"`       // The label of the DSL
+	Description string    `json:"description,omitempty"` // The description of the DSL ( markdown or plain text )
+	Tags        []string  `json:"tags,omitempty"`        // The tags of the DSL
+	Readonly    bool      `json:"readonly,omitempty"`    // The DSL is readonly
+	Builtin     bool      `json:"builtin,omitempty"`     // The DSL is builtin
+	Sort        int       `json:"sort,omitempty"`        // The sort of the DSL
+	Mtime       time.Time `json:"mtime,omitempty"`       // The mtime of the DSL
+	Ctime       time.Time `json:"ctime,omitempty"`       // The ctime of the DSL
+}


### PR DESCRIPTION
- Modified the `TESTFOLDER` variable in the Makefile to exclude additional directories for testing.
- Added `types.MetaInfo` to the `MetaData` struct in `types.go` to improve metadata handling in the model.