### PR TITLE
refactor: rename connector creation function and add GetMetaInfo method

### DIFF
--- a/connector/connector.go
+++ b/connector/connector.go
@@ -53,7 +53,7 @@ func LoadSource(source []byte, id string, file string) (Connector, error) {
 		return nil, err
 	}
 
-	c, err := make(dsl.Type)
+	c, err := makeConnector(dsl.Type)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func LoadSource(source []byte, id string, file string) (Connector, error) {
 
 // New create a new connector
 func New(typ string, id string, dsl []byte) (Connector, error) {
-	c, err := make(typ)
+	c, err := makeConnector(typ)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +117,7 @@ func Remove(id string) error {
 	return connector.Close()
 }
 
-func make(typ string) (Connector, error) {
+func makeConnector(typ string) (Connector, error) {
 
 	t, has := types[typ]
 	if !has {

--- a/connector/database/xun.go
+++ b/connector/database/xun.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/yaoapp/gou/application"
 	"github.com/yaoapp/gou/helper"
+	"github.com/yaoapp/gou/types"
 	"github.com/yaoapp/kun/exception"
 	"github.com/yaoapp/xun/capsule"
 	"github.com/yaoapp/xun/dbal"
@@ -24,6 +25,7 @@ type Xun struct {
 	Driver  string           `json:"type"`
 	Version string           `json:"version,omitempty"`
 	Options XunOptions       `json:"options"`
+	types.MetaInfo
 }
 
 // XunOptions the connetion options
@@ -307,4 +309,9 @@ func (x *Xun) Setting() map[string]interface{} {
 		"file":      x.Options.File,
 		"hosts":     x.Options.Hosts,
 	}
+}
+
+// GetMetaInfo returns the meta information
+func (x *Xun) GetMetaInfo() types.MetaInfo {
+	return x.MetaInfo
 }

--- a/connector/fastembed/fastembed.go
+++ b/connector/fastembed/fastembed.go
@@ -3,6 +3,7 @@ package fastembed
 import (
 	"github.com/yaoapp/gou/application"
 	"github.com/yaoapp/gou/helper"
+	"github.com/yaoapp/gou/types"
 	"github.com/yaoapp/xun/dbal/query"
 	"github.com/yaoapp/xun/dbal/schema"
 )
@@ -13,6 +14,7 @@ type Connector struct {
 	file    string
 	Name    string  `json:"name"`
 	Options Options `json:"options"`
+	types.MetaInfo
 }
 
 // Options the fastembed connector option
@@ -80,4 +82,9 @@ func (o *Connector) Setting() map[string]interface{} {
 		"key":   o.Options.Key,
 		"model": o.Options.Model,
 	}
+}
+
+// GetMetaInfo returns the meta information
+func (o *Connector) GetMetaInfo() types.MetaInfo {
+	return o.MetaInfo
 }

--- a/connector/moapi/moapi.go
+++ b/connector/moapi/moapi.go
@@ -3,6 +3,7 @@ package moapi
 import (
 	"github.com/yaoapp/gou/application"
 	"github.com/yaoapp/gou/helper"
+	"github.com/yaoapp/gou/types"
 	"github.com/yaoapp/xun/dbal/query"
 	"github.com/yaoapp/xun/dbal/schema"
 )
@@ -13,6 +14,7 @@ type Connector struct {
 	file    string
 	Name    string  `json:"name"`
 	Options Options `json:"options"`
+	types.MetaInfo
 }
 
 // Options the redis connector option
@@ -75,4 +77,9 @@ func (o *Connector) Setting() map[string]interface{} {
 		"key":   o.Options.Key,
 		"model": o.Options.Model,
 	}
+}
+
+// GetMetaInfo returns the meta information
+func (o *Connector) GetMetaInfo() types.MetaInfo {
+	return o.MetaInfo
 }

--- a/connector/mongo/mongo.go
+++ b/connector/mongo/mongo.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/yaoapp/gou/application"
 	"github.com/yaoapp/gou/helper"
+	"github.com/yaoapp/gou/types"
 	"github.com/yaoapp/xun/dbal/query"
 	"github.com/yaoapp/xun/dbal/schema"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -22,6 +23,7 @@ type Connector struct {
 	Options  Options         `json:"options"`
 	Client   *mongo.Client   `json:"-"`
 	Database *mongo.Database `json:"-"`
+	types.MetaInfo
 }
 
 // Options the connetion options
@@ -176,4 +178,9 @@ func (m *Connector) Setting() map[string]interface{} {
 		"hosts":   m.Options.Hosts,
 		"dsn":     m.Options.dsn,
 	}
+}
+
+// GetMetaInfo returns the meta information
+func (m *Connector) GetMetaInfo() types.MetaInfo {
+	return m.MetaInfo
 }

--- a/connector/openai/openai.go
+++ b/connector/openai/openai.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"github.com/yaoapp/gou/application"
 	"github.com/yaoapp/gou/helper"
+	"github.com/yaoapp/gou/types"
 	"github.com/yaoapp/xun/dbal/query"
 	"github.com/yaoapp/xun/dbal/schema"
 )
@@ -13,6 +14,7 @@ type Connector struct {
 	file    string
 	Name    string  `json:"name"`
 	Options Options `json:"options"`
+	types.MetaInfo
 }
 
 // Options the redis connector option
@@ -78,4 +80,9 @@ func (o *Connector) Setting() map[string]interface{} {
 		"model": o.Options.Model,
 		"azure": o.Options.Azure,
 	}
+}
+
+// GetMetaInfo returns the meta information
+func (o *Connector) GetMetaInfo() types.MetaInfo {
+	return o.MetaInfo
 }

--- a/connector/redis/redis.go
+++ b/connector/redis/redis.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-redis/redis/v8"
 	"github.com/yaoapp/gou/application"
 	"github.com/yaoapp/gou/helper"
+	"github.com/yaoapp/gou/types"
 	"github.com/yaoapp/kun/any"
 	"github.com/yaoapp/xun/dbal/query"
 	"github.com/yaoapp/xun/dbal/schema"
@@ -20,6 +21,7 @@ type Connector struct {
 	Name    string        `json:"name"`
 	Rdb     *redis.Client `json:"-"`
 	Options Options       `json:"options"`
+	types.MetaInfo
 }
 
 // Options the redis connector option
@@ -136,4 +138,9 @@ func (r *Connector) Setting() map[string]interface{} {
 		"pass":    r.Options.Pass,
 		"timeout": r.Options.Timeout,
 	}
+}
+
+// GetMetaInfo returns the meta information
+func (r *Connector) GetMetaInfo() types.MetaInfo {
+	return r.MetaInfo
 }

--- a/connector/types.go
+++ b/connector/types.go
@@ -65,6 +65,7 @@ type Connector interface {
 	ID() string
 	Is(int) bool
 	Setting() map[string]interface{}
+	GetMetaInfo() gouTypes.MetaInfo
 }
 
 // Option the option interface

--- a/graphrag/utils/utils_test.go
+++ b/graphrag/utils/utils_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/yaoapp/gou/connector"
 	"github.com/yaoapp/gou/http"
+	"github.com/yaoapp/gou/types"
 	"github.com/yaoapp/xun/dbal/query"
 	"github.com/yaoapp/xun/dbal/schema"
 )
@@ -40,6 +41,7 @@ func (m *mockConnector) Query() (query.Query, error)                       { ret
 func (m *mockConnector) Schema() (schema.Schema, error)                    { return nil, nil }
 func (m *mockConnector) Close() error                                      { return nil }
 func (m *mockConnector) Setting() map[string]interface{}                   { return m.settings }
+func (m *mockConnector) GetMetaInfo() types.MetaInfo                       { return types.MetaInfo{} }
 
 func TestPostLLM_LocalLLM(t *testing.T) {
 	// Read environment variables for local LLM

--- a/mcp/client/client.go
+++ b/mcp/client/client.go
@@ -6,6 +6,7 @@ import (
 	goclient "github.com/mark3labs/mcp-go/client"
 
 	"github.com/yaoapp/gou/mcp/types"
+	gouTypes "github.com/yaoapp/gou/types"
 )
 
 // Client the MCP Client
@@ -64,4 +65,9 @@ func New(dsl *types.ClientDSL) (*Client, error) {
 	}
 
 	return client, nil
+}
+
+// GetMetaInfo returns the meta information of the client
+func (c *Client) GetMetaInfo() gouTypes.MetaInfo {
+	return c.DSL.MetaInfo
 }

--- a/mcp/interfaces.go
+++ b/mcp/interfaces.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/yaoapp/gou/mcp/types"
+	gouTypes "github.com/yaoapp/gou/types"
 )
 
 // Client the MCP client interface
@@ -51,6 +52,9 @@ type Client interface {
 	OnEvent(eventType string, handler func(event types.Event))
 	OnNotification(method string, handler types.NotificationHandler)
 	OnError(handler types.ErrorHandler)
+
+	// Get meta info
+	GetMetaInfo() gouTypes.MetaInfo
 }
 
 // Server the MCP service interface

--- a/model/model.go
+++ b/model/model.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/yaoapp/gou/application"
+	"github.com/yaoapp/gou/types"
 	"github.com/yaoapp/kun/exception"
 	"github.com/yaoapp/kun/log"
 	"github.com/yaoapp/kun/maps"
@@ -184,7 +185,7 @@ func (mod *Model) Migrate(force bool, opts ...MigrateOption) error {
 
 		if !options.DonotInsertValues {
 			_, errs := mod.InsertValues()
-			if errs != nil && len(errs) > 0 {
+			if len(errs) > 0 {
 				for _, err := range errs {
 					log.Error("[Migrate] %s", err.Error())
 				}
@@ -267,4 +268,9 @@ func (mod *Model) Validate(row maps.MapStrAny) []ValidateResponse {
 		}
 	}
 	return res
+}
+
+// GetMetaInfo returns the meta information of the model
+func (mod *Model) GetMetaInfo() types.MetaInfo {
+	return mod.MetaData.MetaInfo
 }


### PR DESCRIPTION
- Renamed the `make` function to `makeConnector` for clarity in connector creation.
- Added `GetMetaInfo` method to various connector types to enhance metadata retrieval.
- Updated the `Connector` interface to include the new `GetMetaInfo` method, ensuring consistency across implementations.
- Improved metadata handling in the model by introducing a `GetMetaInfo` method for better integration with the overall system.