### PR TITLE
feat: enhance model loading with soft delete and permission columns

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -66,17 +66,6 @@ func LoadSource(source []byte, id string, file string) (*Model, error) {
 	PrimaryKey := "id"
 	uniqueColumns := []*Column{}
 
-	// Add soft delete column if enabled
-	if mod.MetaData.Option.SoftDeletes {
-		mod.MetaData.Columns = append(mod.MetaData.Columns, Column{
-			Label:    "::Delete At",
-			Name:     "deleted_at",
-			Type:     "timestamp",
-			Comment:  "::Delete At",
-			Nullable: true,
-		})
-	}
-
 	// Add timestamp columns if enabled
 	if mod.MetaData.Option.Timestamps {
 		mod.MetaData.Columns = append(mod.MetaData.Columns,
@@ -97,6 +86,17 @@ func LoadSource(source []byte, id string, file string) (*Model, error) {
 		)
 	}
 
+	// Add soft delete column if enabled
+	if mod.MetaData.Option.SoftDeletes {
+		mod.MetaData.Columns = append(mod.MetaData.Columns, Column{
+			Label:    "::Delete At",
+			Name:     "deleted_at",
+			Type:     "timestamp",
+			Comment:  "::Delete At",
+			Nullable: true,
+		})
+	}
+
 	for i, column := range mod.MetaData.Columns {
 		mod.MetaData.Columns[i].model = mod
 		columns[column.Name] = &mod.MetaData.Columns[i]
@@ -108,6 +108,71 @@ func LoadSource(source []byte, id string, file string) (*Model, error) {
 		if column.Unique || column.Primary {
 			uniqueColumns = append(uniqueColumns, columns[column.Name])
 		}
+	}
+
+	// Add permission columns if enabled
+	if mod.MetaData.Option.Permission {
+		mod.MetaData.Columns = append(mod.MetaData.Columns,
+			Column{
+				Label:    "::Created By",
+				Name:     "__yao_created_by",
+				Type:     "string",
+				Comment:  "::Created By User ID",
+				Nullable: true,
+				Length:   128,
+				Index:    true,
+			},
+			Column{
+				Label:    "::Updated By",
+				Name:     "__yao_updated_by",
+				Type:     "string",
+				Comment:  "::Updated By User ID",
+				Nullable: true,
+				Length:   128,
+			},
+			Column{
+				Label:    "::Team ID",
+				Name:     "__yao_team_id",
+				Type:     "string",
+				Comment:  "::Team ID",
+				Nullable: true,
+				Length:   128,
+				Index:    true,
+			},
+			Column{
+				Label:    "::Tenant ID",
+				Name:     "__yao_tenant_id",
+				Type:     "string",
+				Comment:  "::Tenant ID",
+				Nullable: true,
+				Length:   128,
+				Index:    true,
+			},
+			Column{
+				Label:    "::Public Read",
+				Name:     "__yao_public_read",
+				Type:     "boolean",
+				Comment:  "::Public Read Permission",
+				Nullable: false,
+				Default:  false,
+			},
+			Column{
+				Label:    "::Public Write",
+				Name:     "__yao_public_write",
+				Type:     "boolean",
+				Comment:  "::Public Write Permission",
+				Nullable: false,
+				Default:  false,
+			},
+			Column{
+				Label:    "::Inherit From",
+				Name:     "__yao_inherit_from",
+				Type:     "string",
+				Comment:  "::Inherit Permission From Parent Resource ID",
+				Nullable: true,
+				Length:   128,
+			},
+		)
 	}
 
 	// Process unique indexes (avoid duplicates)


### PR DESCRIPTION
- Reintroduced the soft delete column in the LoadSource function, ensuring it is added when enabled.
- Added new permission columns for tracking created by, updated by, team ID, tenant ID, and public read/write permissions, enhancing the model's capability for access control.
- Improved code organization and clarity with comments detailing the new additions.