### PR TITLE
refactor: update pagination options from BatchSize to Limit

### DIFF
--- a/graphrag/segment.go
+++ b/graphrag/segment.go
@@ -656,7 +656,7 @@ func (g *GraphRag) GetSegments(ctx context.Context, segmentIDs []string) ([]type
 	return segments, nil
 }
 
-// ListSegments lists segments of a document with pagination
+// ListSegments lists segments of a document with pagination (deprecated)
 func (g *GraphRag) ListSegments(ctx context.Context, docID string, options *types.ListSegmentsOptions) (*types.PaginatedSegmentsResult, error) {
 	if docID == "" {
 		return nil, fmt.Errorf("docID cannot be empty")
@@ -732,10 +732,10 @@ func (g *GraphRag) ScrollSegments(ctx context.Context, docID string, options *ty
 		options = &types.ScrollSegmentsOptions{}
 	}
 
-	// Set default batch size
-	batchSize := options.BatchSize
-	if batchSize <= 0 {
-		batchSize = 100 // Default batch size
+	// Set default limit
+	limit := options.Limit
+	if limit <= 0 {
+		limit = 100 // Default limit
 	}
 
 	// Query segment data from all configured databases with scroll
@@ -743,9 +743,10 @@ func (g *GraphRag) ScrollSegments(ctx context.Context, docID string, options *ty
 		GraphName:            graphName,
 		DocID:                docID,
 		QueryType:            "scroll",
-		BatchSize:            batchSize,
+		BatchSize:            limit,
 		ScrollID:             options.ScrollID,
 		Filter:               options.Filter,
+		OrderBy:              options.OrderBy,
 		Fields:               options.Fields,
 		IncludeNodes:         options.IncludeNodes,
 		IncludeRelationships: options.IncludeRelationships,
@@ -1615,18 +1616,19 @@ func (g *GraphRag) queryChunksFromVectorWithScroll(ctx context.Context, collecti
 		}
 	}
 
-	// Set batch size, using default if not provided
-	batchSize := opts.BatchSize
-	if batchSize <= 0 {
-		batchSize = 100
+	// Set limit, using default if not provided
+	limit := opts.BatchSize
+	if limit <= 0 {
+		limit = 100
 	}
 
 	// Scroll documents
 	scrollOpts := &types.ScrollOptions{
 		CollectionName: collectionName,
 		Filter:         filter,
-		BatchSize:      batchSize,
+		Limit:          limit,
 		ScrollID:       opts.ScrollID,
+		OrderBy:        opts.OrderBy,
 		Fields:         opts.Fields,
 		IncludeVector:  false,
 		IncludePayload: true,

--- a/graphrag/segment_test.go
+++ b/graphrag/segment_test.go
@@ -704,7 +704,7 @@ func TestSegmentCURD(t *testing.T) {
 
 				// Test ScrollSegments with default options
 				scrollOptions := &types.ScrollSegmentsOptions{
-					BatchSize: 10,
+					Limit: 10,
 				}
 				result, err := g.ScrollSegments(ctx, scrollDocID, scrollOptions)
 				if err != nil {

--- a/graphrag/types/interfaces.go
+++ b/graphrag/types/interfaces.go
@@ -28,7 +28,7 @@ type VectorStore interface {
 	DeleteDocuments(ctx context.Context, opts *DeleteDocumentOptions) error
 
 	// Document Listing and Pagination
-	ListDocuments(ctx context.Context, opts *ListDocumentsOptions) (*PaginatedDocumentsResult, error)
+	ListDocuments(ctx context.Context, opts *ListDocumentsOptions) (*PaginatedDocumentsResult, error) // deprecated
 	ScrollDocuments(ctx context.Context, opts *ScrollOptions) (*ScrollResult, error)
 
 	// Vector Search Operations (core functionality)

--- a/graphrag/types/types.go
+++ b/graphrag/types/types.go
@@ -1348,12 +1348,13 @@ type PaginatedDocumentsResult struct {
 // ScrollOptions represents options for scrolling through documents (iterator-style)
 type ScrollOptions struct {
 	CollectionName string                 `json:"collection_name"`
-	Filter         map[string]interface{} `json:"filter,omitempty"`     // Metadata filter
-	BatchSize      int                    `json:"batch_size,omitempty"` // Number of documents per batch (default: 100)
-	ScrollID       string                 `json:"scroll_id,omitempty"`  // Scroll ID for continuing pagination
-	IncludeVector  bool                   `json:"include_vector"`       // Whether to include vector data
-	IncludePayload bool                   `json:"include_payload"`      // Whether to include payload/metadata
-	Fields         []string               `json:"fields,omitempty"`     // Specific fields to retrieve
+	Filter         map[string]interface{} `json:"filter,omitempty"`    // Metadata filter
+	Limit          int                    `json:"limit,omitempty"`     // Number of documents per batch (default: 100)
+	ScrollID       string                 `json:"scroll_id,omitempty"` // Scroll ID for continuing pagination
+	OrderBy        []string               `json:"order_by,omitempty"`  // Fields to order by
+	IncludeVector  bool                   `json:"include_vector"`      // Whether to include vector data
+	IncludePayload bool                   `json:"include_payload"`     // Whether to include payload/metadata
+	Fields         []string               `json:"fields,omitempty"`    // Specific fields to retrieve
 }
 
 // ScrollResult represents scroll-based query results
@@ -2153,10 +2154,11 @@ type PaginatedSegmentsResult struct {
 
 // ScrollSegmentsOptions represents options for scrolling through segments (iterator-style)
 type ScrollSegmentsOptions struct {
-	Filter    map[string]interface{} `json:"filter,omitempty"`     // Metadata filter (vote, score, weight, etc.)
-	BatchSize int                    `json:"batch_size,omitempty"` // Number of segments per batch (default: 100)
-	ScrollID  string                 `json:"scroll_id,omitempty"`  // Scroll ID for continuing pagination
-	Fields    []string               `json:"fields,omitempty"`     // Specific fields to retrieve
+	Filter   map[string]interface{} `json:"filter,omitempty"`    // Metadata filter (vote, score, weight, etc.)
+	Limit    int                    `json:"limit,omitempty"`     // Number of segments per batch (default: 100)
+	ScrollID string                 `json:"scroll_id,omitempty"` // Scroll ID for continuing pagination
+	OrderBy  []string               `json:"order_by,omitempty"`  // Fields to order by (score, weight, vote, created_at, etc.)
+	Fields   []string               `json:"fields,omitempty"`    // Specific fields to retrieve
 
 	// Include options
 	IncludeNodes         bool `json:"include_nodes"`         // Whether to include graph nodes

--- a/graphrag/vector/qdrant/document_test.go
+++ b/graphrag/vector/qdrant/document_test.go
@@ -1158,7 +1158,7 @@ func TestScrollDocuments(t *testing.T) {
 			setup: func() *types.ScrollOptions {
 				return &types.ScrollOptions{
 					CollectionName: collectionName,
-					BatchSize:      10,
+					Limit:          10,
 					IncludeVector:  true,
 					IncludePayload: true,
 				}
@@ -1172,7 +1172,7 @@ func TestScrollDocuments(t *testing.T) {
 			setup: func() *types.ScrollOptions {
 				return &types.ScrollOptions{
 					CollectionName: collectionName,
-					BatchSize:      5,
+					Limit:          5,
 					IncludeVector:  true,
 					IncludePayload: true,
 				}
@@ -1186,7 +1186,7 @@ func TestScrollDocuments(t *testing.T) {
 			setup: func() *types.ScrollOptions {
 				return &types.ScrollOptions{
 					CollectionName: collectionName,
-					BatchSize:      10,
+					Limit:          10,
 					IncludeVector:  false,
 					IncludePayload: true,
 				}
@@ -1200,7 +1200,7 @@ func TestScrollDocuments(t *testing.T) {
 			setup: func() *types.ScrollOptions {
 				return &types.ScrollOptions{
 					CollectionName: collectionName,
-					BatchSize:      10,
+					Limit:          10,
 					IncludeVector:  true,
 					IncludePayload: false,
 				}
@@ -1214,7 +1214,7 @@ func TestScrollDocuments(t *testing.T) {
 			setup: func() *types.ScrollOptions {
 				return &types.ScrollOptions{
 					CollectionName: collectionName,
-					BatchSize:      10,
+					Limit:          10,
 					Filter: map[string]interface{}{
 						"batch": 1, // Should match documents 5-9
 					},
@@ -1239,7 +1239,7 @@ func TestScrollDocuments(t *testing.T) {
 			setup: func() *types.ScrollOptions {
 				return &types.ScrollOptions{
 					CollectionName: collectionName,
-					BatchSize:      10,
+					Limit:          10,
 				}
 			},
 			wantErr:     true,
@@ -1385,7 +1385,7 @@ func TestDocumentOperationsIntegration(t *testing.T) {
 		// Step 4: Scroll documents
 		scrollOpts := types.ScrollOptions{
 			CollectionName: collectionName,
-			BatchSize:      7,
+			Limit:          7,
 			IncludeVector:  true,
 			IncludePayload: true,
 		}
@@ -1659,7 +1659,7 @@ func BenchmarkScrollDocuments(b *testing.B) {
 		b.Run(bm.name, func(b *testing.B) {
 			opts := &types.ScrollOptions{
 				CollectionName: collectionName,
-				BatchSize:      bm.batchSize,
+				Limit:          bm.batchSize,
 				IncludeVector:  true,
 				IncludePayload: true,
 			}
@@ -2472,7 +2472,7 @@ func TestScrollDocumentsInvalidScrollID(t *testing.T) {
 		// Test with invalid scroll ID (should be ignored gracefully)
 		scrollOpts := types.ScrollOptions{
 			CollectionName: env.CollectionName,
-			BatchSize:      10,
+			Limit:          10,
 			ScrollID:       "invalid_scroll_id", // Invalid format, should be ignored
 			IncludeVector:  true,
 			IncludePayload: true,
@@ -2650,7 +2650,7 @@ func TestScrollDocumentsWithScrollID(t *testing.T) {
 		// Test with valid numeric scroll ID
 		scrollOpts := types.ScrollOptions{
 			CollectionName: env.CollectionName,
-			BatchSize:      5,
+			Limit:          5,
 			ScrollID:       "12345", // Valid numeric string
 			IncludeVector:  true,
 			IncludePayload: true,
@@ -2763,7 +2763,7 @@ func TestScrollDocumentsWithFilter(t *testing.T) {
 		// Test scroll with filter to trigger convertFilterToQdrant error path
 		scrollOpts := types.ScrollOptions{
 			CollectionName: env.CollectionName,
-			BatchSize:      5,
+			Limit:          5,
 			Filter: map[string]interface{}{
 				"test_filter": true,
 			},
@@ -2828,7 +2828,7 @@ func TestScrollDocumentsErrorPath(t *testing.T) {
 		// Test with invalid collection name to trigger error
 		scrollOpts := types.ScrollOptions{
 			CollectionName: "nonexistent_collection_scroll",
-			BatchSize:      10,
+			Limit:          10,
 			IncludeVector:  true,
 			IncludePayload: true,
 		}


### PR DESCRIPTION
- Changed the BatchSize field to Limit in ScrollOptions and ScrollSegmentsOptions for consistency across the codebase.
- Updated related methods and tests to reflect this change, ensuring uniformity in pagination handling.
- Marked ListSegments and ListDocuments methods as deprecated to signal upcoming changes in their usage.