### PR TITLE
refactor: update segment management methods to include docID parameter

### DIFF
--- a/graphrag/segment_test.go
+++ b/graphrag/segment_test.go
@@ -520,7 +520,7 @@ func TestSegmentCURD(t *testing.T) {
 				}
 
 				// Test GetSegments with specific IDs
-				segments, err := g.GetSegments(ctx, []string{"read_segment_001", "read_segment_002"})
+				segments, err := g.GetSegments(ctx, readDocID, []string{"read_segment_001", "read_segment_002"})
 				if err != nil {
 					t.Logf("Failed to get segments by IDs (expected): %v", err)
 					return
@@ -770,7 +770,7 @@ func TestSegmentCURD(t *testing.T) {
 				}
 
 				// Test GetSegment with specific ID
-				segment, err := g.GetSegment(ctx, "single_segment_001")
+				segment, err := g.GetSegment(ctx, singleReadDocID, "single_segment_001")
 				if err != nil {
 					t.Logf("Failed to get single segment (expected): %v", err)
 					return
@@ -798,7 +798,7 @@ func TestSegmentCURD(t *testing.T) {
 			// Step 7e: Test read error handling
 			t.Run("Read_Error_Handling", func(t *testing.T) {
 				// Test GetSegments with empty segment list
-				emptySegments, err := g.GetSegments(ctx, []string{})
+				emptySegments, err := g.GetSegments(ctx, "test_doc", []string{})
 				if err != nil {
 					t.Errorf("GetSegments with empty list should not return error: %v", err)
 				}
@@ -807,7 +807,7 @@ func TestSegmentCURD(t *testing.T) {
 				}
 
 				// Test GetSegments with non-existent segment IDs
-				nonExistentSegments, err := g.GetSegments(ctx, []string{"non_existent_segment"})
+				nonExistentSegments, err := g.GetSegments(ctx, "test_doc", []string{"non_existent_segment"})
 				if err == nil {
 					t.Logf("GetSegments with non-existent IDs handled gracefully: returned %d segments", len(nonExistentSegments))
 				} else {
@@ -830,8 +830,16 @@ func TestSegmentCURD(t *testing.T) {
 					t.Logf("ListSegments with non-existent docID returned error (expected): %v", err)
 				}
 
+				// Test GetSegment with empty docID
+				_, err = g.GetSegment(ctx, "", "test_segment")
+				if err == nil {
+					t.Error("Expected error for GetSegment with empty docID")
+				} else {
+					t.Logf("GetSegment correctly rejected empty docID: %v", err)
+				}
+
 				// Test GetSegment with empty segmentID
-				_, err = g.GetSegment(ctx, "")
+				_, err = g.GetSegment(ctx, "test_doc", "")
 				if err == nil {
 					t.Error("Expected error for GetSegment with empty segmentID")
 				} else {
@@ -839,7 +847,7 @@ func TestSegmentCURD(t *testing.T) {
 				}
 
 				// Test GetSegment with non-existent segmentID
-				nonExistentSegment, err := g.GetSegment(ctx, "non_existent_single_segment")
+				nonExistentSegment, err := g.GetSegment(ctx, "test_doc", "non_existent_single_segment")
 				if err == nil {
 					t.Logf("GetSegment with non-existent ID handled gracefully: returned %v", nonExistentSegment)
 				} else {
@@ -883,7 +891,7 @@ func TestSegmentCURD(t *testing.T) {
 				}
 
 				// Test removing specific segments by IDs
-				removeCount, err := g.RemoveSegments(ctx, []string{"remove_segment_001"})
+				removeCount, err := g.RemoveSegments(ctx, removeDocID, []string{"remove_segment_001"})
 				if err != nil {
 					t.Logf("Failed to remove segments (expected): %v", err)
 					return
@@ -897,7 +905,7 @@ func TestSegmentCURD(t *testing.T) {
 				t.Logf("Successfully removed %d segments by IDs", removeCount)
 
 				// Test removing remaining segments
-				remainingCount, err := g.RemoveSegments(ctx, []string{"remove_segment_002"})
+				remainingCount, err := g.RemoveSegments(ctx, removeDocID, []string{"remove_segment_002"})
 				if err != nil {
 					t.Logf("Failed to remove remaining segments (expected): %v", err)
 					return
@@ -968,7 +976,7 @@ func TestSegmentCURD(t *testing.T) {
 			// Step 10: Test RemoveSegments error handling
 			t.Run("Remove_Segments_Error_Handling", func(t *testing.T) {
 				// Test with empty segment list
-				emptyRemoveCount, err := g.RemoveSegments(ctx, []string{})
+				emptyRemoveCount, err := g.RemoveSegments(ctx, "test_doc", []string{})
 				if err != nil {
 					t.Errorf("RemoveSegments with empty list should not return error: %v", err)
 				}
@@ -977,7 +985,7 @@ func TestSegmentCURD(t *testing.T) {
 				}
 
 				// Test with non-existent segment IDs
-				nonExistentCount, err := g.RemoveSegments(ctx, []string{"non_existent_segment"})
+				nonExistentCount, err := g.RemoveSegments(ctx, "test_doc", []string{"non_existent_segment"})
 				if err == nil {
 					t.Logf("RemoveSegments with non-existent IDs handled gracefully: removed %d", nonExistentCount)
 				} else {

--- a/graphrag/store_test.go
+++ b/graphrag/store_test.go
@@ -70,7 +70,7 @@ func TestUpdateStoreFunctions(t *testing.T) {
 			t.Run("Update_Vote", func(t *testing.T) {
 				// Test with empty arrays
 				votes := []types.SegmentVote{}
-				updatedCount, err := g.UpdateVote(ctx, votes)
+				updatedCount, err := g.UpdateVote(ctx, "test_doc", votes)
 				if err != nil {
 					t.Errorf("Config %s: UpdateVote with empty array should not fail: %v", configName, err)
 				}
@@ -79,7 +79,7 @@ func TestUpdateStoreFunctions(t *testing.T) {
 				}
 
 				// Test with nil array
-				updatedCount, err = g.UpdateVote(ctx, nil)
+				updatedCount, err = g.UpdateVote(ctx, "test_doc", nil)
 				if err != nil {
 					t.Errorf("Config %s: UpdateVote with nil array should not fail: %v", configName, err)
 				}
@@ -93,7 +93,7 @@ func TestUpdateStoreFunctions(t *testing.T) {
 			// Test UpdateScore
 			t.Run("Update_Score", func(t *testing.T) {
 				scores := []types.SegmentScore{}
-				updatedCount, err := g.UpdateScore(ctx, scores)
+				updatedCount, err := g.UpdateScore(ctx, "test_doc", scores)
 				if err != nil {
 					t.Errorf("Config %s: UpdateScore with empty array should not fail: %v", configName, err)
 				}
@@ -102,7 +102,7 @@ func TestUpdateStoreFunctions(t *testing.T) {
 				}
 
 				// Test with nil array
-				updatedCount, err = g.UpdateScore(ctx, nil)
+				updatedCount, err = g.UpdateScore(ctx, "test_doc", nil)
 				if err != nil {
 					t.Errorf("Config %s: UpdateScore with nil array should not fail: %v", configName, err)
 				}
@@ -116,7 +116,7 @@ func TestUpdateStoreFunctions(t *testing.T) {
 			// Test UpdateWeight
 			t.Run("Update_Weight", func(t *testing.T) {
 				weights := []types.SegmentWeight{}
-				updatedCount, err := g.UpdateWeight(ctx, weights)
+				updatedCount, err := g.UpdateWeight(ctx, "test_doc", weights)
 				if err != nil {
 					t.Errorf("Config %s: UpdateWeight with empty array should not fail: %v", configName, err)
 				}
@@ -125,7 +125,7 @@ func TestUpdateStoreFunctions(t *testing.T) {
 				}
 
 				// Test with nil array
-				updatedCount, err = g.UpdateWeight(ctx, nil)
+				updatedCount, err = g.UpdateWeight(ctx, "test_doc", nil)
 				if err != nil {
 					t.Errorf("Config %s: UpdateWeight with nil array should not fail: %v", configName, err)
 				}

--- a/graphrag/types/interfaces.go
+++ b/graphrag/types/interfaces.go
@@ -175,17 +175,17 @@ type GraphRag interface {
 	// Segment Management
 	AddSegments(ctx context.Context, docID string, segmentTexts []SegmentText, options *UpsertOptions) ([]string, error) // Add segments to a document manually, return segment IDs
 	UpdateSegments(ctx context.Context, segmentTexts []SegmentText, options *UpsertOptions) (int, error)                 // Update segments manually, return updated count
-	RemoveSegments(ctx context.Context, segmentIDs []string) (int, error)                                                // Remove segments by SegmentIDs, return removed count
+	RemoveSegments(ctx context.Context, docID string, segmentIDs []string) (int, error)                                  // Remove segments by SegmentIDs, return removed count
 	RemoveSegmentsByDocID(ctx context.Context, docID string) (int, error)                                                // Remove all segments of a document, return removed count
-	GetSegments(ctx context.Context, segmentIDs []string) ([]Segment, error)                                             // Get segments by IDs, return segments
-	GetSegment(ctx context.Context, segmentID string) (*Segment, error)                                                  // Get a single segment by ID, return segment
+	GetSegments(ctx context.Context, docID string, segmentIDs []string) ([]Segment, error)                               // Get segments by IDs, return segments
+	GetSegment(ctx context.Context, docID string, segmentID string) (*Segment, error)                                    // Get a single segment by ID, return segment
 	// ListSegments(ctx context.Context, docID string, options *ListSegmentsOptions) (*PaginatedSegmentsResult, error)      // List segments with pagination, return segments Deprecated
 	ScrollSegments(ctx context.Context, docID string, options *ScrollSegmentsOptions) (*SegmentScrollResult, error) // Scroll segments with iterator-style pagination, return segments
 
 	// Segment Voting, Scoring, Weighting
-	UpdateVote(ctx context.Context, segments []SegmentVote) (int, error)     // Vote for segments, return updated count
-	UpdateScore(ctx context.Context, segments []SegmentScore) (int, error)   // Score for segments, return updated count
-	UpdateWeight(ctx context.Context, segments []SegmentWeight) (int, error) // Weight for segments, return updated count
+	UpdateVote(ctx context.Context, docID string, segments []SegmentVote) (int, error)     // Vote for segments, return updated count
+	UpdateScore(ctx context.Context, docID string, segments []SegmentScore) (int, error)   // Score for segments, return updated count
+	UpdateWeight(ctx context.Context, docID string, segments []SegmentWeight) (int, error) // Weight for segments, return updated count
 
 	// Search Management
 	Search(ctx context.Context, options *QueryOptions, callback ...SearcherProgress) ([]Segment, error)                  // Search for segments


### PR DESCRIPTION
- Modified GetSegments, GetSegment, RemoveSegments, UpdateVote, UpdateScore, and UpdateWeight methods to accept a docID parameter, enhancing their functionality and ensuring proper document context during operations.
- Updated related tests to reflect these changes, ensuring comprehensive coverage for the new method signatures and error handling for empty docID cases.
- Removed the getDocIDFromExistingSegments function as it is no longer needed with the new approach.