### PR TITLE
feat: enhance chunk metadata handling in document processing

### DIFF
--- a/graphrag/document.go
+++ b/graphrag/document.go
@@ -719,6 +719,14 @@ func (g *GraphRag) storeAllDocumentsToVectorStore(ctx context.Context, opts *Sto
 			metadata[k] = v
 		}
 
+		// User set metadata will overwrite this
+		if chunk.Metadata != nil {
+			// Add chunk metadata (User metadata will overwrite this)
+			for k, v := range chunk.Metadata {
+				metadata[k] = v
+			}
+		}
+
 		// Add convert metadata
 		for k, v := range opts.ConvertMetadata {
 			metadata[k] = v

--- a/graphrag/segment.go
+++ b/graphrag/segment.go
@@ -659,6 +659,7 @@ func (g *GraphRag) convertSegmentTextsToChunks(segmentTexts []types.SegmentText,
 			TextPos:   nil,
 			MediaPos:  nil,
 			Extracted: nil,
+			Metadata:  nil,
 		}
 
 		// Merge metadata from existing segment and new segment
@@ -693,6 +694,9 @@ func (g *GraphRag) applyMetadataToChunk(chunk *types.Chunk, metadata map[string]
 	if metadata == nil {
 		return
 	}
+
+	// Add metadata to chunk
+	chunk.Metadata = metadata
 
 	// Extract chunk structure information from metadata
 	if chunkDetails, ok := metadata["chunk_details"].(map[string]interface{}); ok {

--- a/graphrag/types/types.go
+++ b/graphrag/types/types.go
@@ -160,6 +160,9 @@ type Chunk struct {
 
 	// Extracted text
 	Extracted *ExtractionResult `json:"extracted,omitempty"` // Extracted text from the chunk
+
+	// Metadata of the chunk
+	Metadata map[string]interface{} `json:"metadata,omitempty"` // Metadata of the chunk
 }
 
 // Embeddings is a slice of EmbeddingResult


### PR DESCRIPTION
- Added support for user-defined metadata in the document storage process, allowing it to overwrite default metadata.
- Initialized chunk metadata in the chunk creation process, ensuring that metadata is consistently applied and accessible.
- Improved the overall structure of metadata handling within the GraphRag package, enhancing flexibility and robustness in document processing.