### PR TITLE
feat: add segment parent retrieval and tree structure management

### DIFF
--- a/graphrag/types/interfaces.go
+++ b/graphrag/types/interfaces.go
@@ -181,6 +181,7 @@ type GraphRag interface {
 	RemoveSegmentsByDocID(ctx context.Context, docID string) (int, error)                                                // Remove all segments of a document, return removed count
 	GetSegments(ctx context.Context, docID string, segmentIDs []string) ([]Segment, error)                               // Get segments by IDs, return segments
 	GetSegment(ctx context.Context, docID string, segmentID string) (*Segment, error)                                    // Get a single segment by ID, return segment
+	GetSegmentParents(ctx context.Context, docID string, segmentID string) (*SegmentTree, error)                         // Get parent tree of a given segment, return hierarchical tree structure
 	// ListSegments(ctx context.Context, docID string, options *ListSegmentsOptions) (*PaginatedSegmentsResult, error)      // List segments with pagination, return segments Deprecated
 	ScrollSegments(ctx context.Context, docID string, options *ScrollSegmentsOptions) (*SegmentScrollResult, error) // Scroll segments with iterator-style pagination, return segments
 

--- a/graphrag/types/segment.go
+++ b/graphrag/types/segment.go
@@ -4,3 +4,30 @@ package types
 func (segment *Segment) GetText() string {
 	return segment.Text
 }
+
+// ================================================================================================
+// SegmentTree Methods
+// ================================================================================================
+
+// IsRoot returns true if this node has no parent
+func (st *SegmentTree) IsRoot() bool {
+	return st.Parent == nil
+}
+
+// GetParentChain returns the parent chain from current segment to root
+func (st *SegmentTree) GetParentChain() []*Segment {
+	var parents []*Segment
+	current := st.Parent
+
+	// Walk up the parent chain
+	for current != nil {
+		if current.Segment != nil {
+			parents = append(parents, current.Segment)
+			current = current.Parent
+		} else {
+			break
+		}
+	}
+
+	return parents
+}

--- a/graphrag/types/types.go
+++ b/graphrag/types/types.go
@@ -2208,6 +2208,13 @@ type SegmentText struct {
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
 }
 
+// SegmentTree represents a hierarchical tree structure of segment parents
+type SegmentTree struct {
+	Segment *Segment     `json:"segment"`          // The segment node
+	Parent  *SegmentTree `json:"parent,omitempty"` // Parent node (only one in document hierarchy)
+	Depth   int          `json:"depth"`            // Depth in the original document hierarchy (extracted from metadata)
+}
+
 // SegmentReaction represents a reaction for a segment
 type SegmentReaction struct {
 	Source    string                 `json:"source,omitempty"`    // Source of the reaction, e.g. "chat", "api", "bot", etc.


### PR DESCRIPTION
- Introduced GetSegmentParents method to retrieve the parent tree of a given segment, enhancing hierarchical data access.
- Implemented buildSegmentTree method for recursive construction of segment parent trees based on metadata.
- Added utility methods for extracting parent IDs and depth from segment metadata, improving data handling.
- Enhanced SegmentTree struct with methods for determining root status and retrieving parent chains, facilitating better segment management.