### PR TITLE
feat(connector): add support for protocols in OpenAI and Anthropic co…

### DIFF
--- a/connector/anthropic/anthropic.go
+++ b/connector/anthropic/anthropic.go
@@ -38,6 +38,10 @@ type Options struct {
 	// Request parameters
 	MaxTokens   int      `json:"max_tokens,omitempty"`  // Maximum tokens for response (required for Anthropic)
 	Temperature *float64 `json:"temperature,omitempty"` // Temperature (use pointer to distinguish 0 from unset)
+
+	// Supported API protocols. Defaults to ["anthropic"] when empty.
+	// Dual-protocol gateways declare ["openai", "anthropic"].
+	Protocols []string `json:"protocols,omitempty"`
 }
 
 // Capabilities is an alias for llm.Capabilities for backward compatibility.
@@ -145,6 +149,10 @@ func (c *Connector) Setting() map[string]interface{} {
 	// Add temperature if specified
 	if c.Options.Temperature != nil {
 		setting["temperature"] = *c.Options.Temperature
+	}
+
+	if len(c.Options.Protocols) > 0 {
+		setting["protocols"] = c.Options.Protocols
 	}
 
 	return setting

--- a/connector/connector_test.go
+++ b/connector/connector_test.go
@@ -316,6 +316,89 @@ func TestLoadSourceSync(t *testing.T) {
 	// assert.True(t, redis.Is(REDIS))
 }
 
+func TestOpenAI_WithProtocols(t *testing.T) {
+	src := []byte(`{
+		"type": "openai",
+		"name": "dual-proto",
+		"options": {
+			"host": "https://api.yao.run",
+			"model": "kimi-k2.5",
+			"key": "sk-test",
+			"protocols": ["openai", "anthropic"]
+		}
+	}`)
+	conn, err := LoadSource(src, "openai-proto-test", "openai-proto.conn.yao")
+	assert.NoError(t, err)
+
+	setting := conn.Setting()
+	protocols, ok := setting["protocols"].([]string)
+	assert.True(t, ok, "protocols should be []string")
+	assert.Equal(t, []string{"openai", "anthropic"}, protocols)
+
+	delete(Connectors, "openai-proto-test")
+}
+
+func TestOpenAI_WithoutProtocols(t *testing.T) {
+	src := []byte(`{
+		"type": "openai",
+		"name": "standard",
+		"options": {
+			"host": "https://api.openai.com",
+			"model": "gpt-4o",
+			"key": "sk-test"
+		}
+	}`)
+	conn, err := LoadSource(src, "openai-noproto-test", "openai-noproto.conn.yao")
+	assert.NoError(t, err)
+
+	setting := conn.Setting()
+	_, hasProtocols := setting["protocols"]
+	assert.False(t, hasProtocols, "protocols should not be present when not configured")
+
+	delete(Connectors, "openai-noproto-test")
+}
+
+func TestAnthropic_WithProtocols(t *testing.T) {
+	src := []byte(`{
+		"type": "anthropic",
+		"name": "dual-proto",
+		"options": {
+			"host": "https://api.yao.run",
+			"model": "claude-sonnet-4-20250514",
+			"key": "sk-ant-test",
+			"protocols": ["openai", "anthropic"]
+		}
+	}`)
+	conn, err := LoadSource(src, "anthropic-proto-test", "anthropic-proto.conn.yao")
+	assert.NoError(t, err)
+
+	setting := conn.Setting()
+	protocols, ok := setting["protocols"].([]string)
+	assert.True(t, ok, "protocols should be []string")
+	assert.Equal(t, []string{"openai", "anthropic"}, protocols)
+
+	delete(Connectors, "anthropic-proto-test")
+}
+
+func TestAnthropic_WithoutProtocols(t *testing.T) {
+	src := []byte(`{
+		"type": "anthropic",
+		"name": "standard",
+		"options": {
+			"model": "claude-sonnet-4-20250514",
+			"key": "sk-ant-test"
+		}
+	}`)
+	conn, err := LoadSource(src, "anthropic-noproto-test", "anthropic-noproto.conn.yao")
+	assert.NoError(t, err)
+
+	setting := conn.Setting()
+	_, hasProtocols := setting["protocols"]
+	assert.False(t, hasProtocols, "protocols should not be present when not configured")
+
+	delete(Connectors, "anthropic-noproto-test")
+}
+
 func prepare(t *testing.T, name string) string {
 	root := os.Getenv("GOU_TEST_APPLICATION")
 	app, err := application.OpenFromDisk(root) // Load app

--- a/connector/openai/openai.go
+++ b/connector/openai/openai.go
@@ -38,6 +38,10 @@ type Options struct {
 	// Request parameters that can be passed to sandbox proxy
 	MaxTokens   int      `json:"max_tokens,omitempty"`  // Maximum tokens for response
 	Temperature *float64 `json:"temperature,omitempty"` // Temperature for response (use pointer to distinguish 0 from unset)
+
+	// Supported API protocols. Defaults to ["openai"] when empty.
+	// Dual-protocol gateways (e.g. LiteLLM) declare ["openai", "anthropic"].
+	Protocols []string `json:"protocols,omitempty"`
 }
 
 // Capabilities is an alias for llm.Capabilities for backward compatibility.
@@ -157,8 +161,10 @@ func (o *Connector) Setting() map[string]interface{} {
 		setting["temperature"] = *o.Options.Temperature
 	}
 
-	// Note: HTTP proxy is handled via HTTPS_PROXY/HTTP_PROXY environment variables
-	// by http.GetTransport, not configured here
+	if len(o.Options.Protocols) > 0 {
+		setting["protocols"] = o.Options.Protocols
+	}
+
 	return setting
 }
 


### PR DESCRIPTION
…nnectors

- Implemented the ability to specify multiple protocols in the OpenAI and Anthropic connector options.
- Enhanced the Setting method to include protocols in the connector settings when configured.
- Added new test cases to validate the behavior of connectors with and without specified protocols, ensuring correct handling and absence of protocols as expected.