### PR TITLE
feat(doc): add unified documentation system with YAML-embedded docs

### DIFF
--- a/api/doc.go
+++ b/api/doc.go
@@ -1,0 +1,11 @@
+package api
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/api/doc.yml
+++ b/api/doc.yml
@@ -1,0 +1,24 @@
+group: api
+type: process
+entries:
+  - name: list
+    desc: List all loaded APIs or filter by specific IDs
+    args:
+      - name: ids
+        type: array
+        required: false
+        desc: Optional array of API IDs to filter by; if omitted, all APIs are returned
+    return:
+      type: object
+      desc: A map of API ID to API definition objects
+
+  - name: reload
+    desc: Reload all API definitions from the specified directory
+    args:
+      - name: root
+        type: string
+        required: false
+        desc: Directory to load APIs from (default "apis")
+    return:
+      type: object
+      desc: Result object with success status, message, and count of loaded APIs

--- a/diff/doc.go
+++ b/diff/doc.go
@@ -1,0 +1,12 @@
+package diff
+
+import (
+	_ "embed"
+
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/diff/doc.yml
+++ b/diff/doc.yml
@@ -1,0 +1,51 @@
+group: diff
+type: process
+entries:
+  - name: diff.Patch
+    desc: Compare two strings and return a unified diff patch string
+    args:
+      - name: text1
+        type: string
+        required: true
+        desc: The original text
+      - name: text2
+        type: string
+        required: true
+        desc: The modified text
+      - name: checklines
+        type: bool
+        required: true
+        desc: Whether to check at line-level first for speedup on large texts
+    return:
+      type: string
+      desc: Unified diff patch string
+
+  - name: diff.Apply
+    desc: Apply a unified diff patch string to the original text
+    args:
+      - name: text
+        type: string
+        required: true
+        desc: The original text to apply the patch to
+      - name: patch
+        type: string
+        required: true
+        desc: The unified diff patch string
+    return:
+      type: string
+      desc: The patched text after applying the diff
+
+  - name: diff.Replace
+    desc: Replace text segments using SEARCH/REPLACE block format
+    args:
+      - name: text
+        type: string
+        required: true
+        desc: The original text
+      - name: patch
+        type: string
+        required: true
+        desc: "The SEARCH/REPLACE patch in <<<<<<< SEARCH / ======= / >>>>>>> REPLACE block format"
+    return:
+      type: string
+      desc: The text after applying all search-and-replace blocks

--- a/doc/auto.go
+++ b/doc/auto.go
@@ -1,0 +1,56 @@
+package doc
+
+import (
+	"sort"
+
+	"github.com/yaoapp/gou/process"
+)
+
+// AutoDiscover compares process.Handlers with registered doc entries and
+// returns a sorted list of handler names that have no documentation.
+func AutoDiscover() []string {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	var undocumented []string
+	for name := range process.Handlers {
+		key := entryKey(TypeProcess, name)
+		if _, ok := entries[key]; ok {
+			continue
+		}
+		undocumented = append(undocumented, name)
+	}
+	sort.Strings(undocumented)
+	return undocumented
+}
+
+// CallableName returns the user-facing callable pattern for a process entry.
+// For dynamic-ID groups (models, schemas, stores, fs, tasks, schedules) the
+// handler key is "group.method" but users call "group.<id>.method", so this
+// function returns "models.<id>.find". For all other groups it returns the
+// entry name as-is.
+func CallableName(e *Entry) string {
+	if e.Type != TypeProcess {
+		return e.Name
+	}
+	if DynamicIDGroups[e.Group] {
+		parts := splitDot(e.Name)
+		if len(parts) == 2 {
+			return parts[0] + ".<id>." + parts[1]
+		}
+	}
+	return e.Name
+}
+
+func splitDot(s string) []string {
+	out := make([]string, 0, 4)
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '.' {
+			out = append(out, s[start:i])
+			start = i + 1
+		}
+	}
+	out = append(out, s[start:])
+	return out
+}

--- a/doc/doc_test.go
+++ b/doc/doc_test.go
@@ -1,0 +1,573 @@
+package doc
+
+import (
+	"testing"
+)
+
+const testYAML = `
+group: test
+type: process
+entries:
+  - name: test.hello
+    desc: Say hello
+    args:
+      - name: name
+        type: string
+        required: true
+        desc: Name to greet
+    return:
+      type: string
+      desc: Greeting message
+
+  - name: test.add
+    desc: Add two numbers
+    args:
+      - name: a
+        type: number
+        required: true
+      - name: b
+        type: number
+        required: true
+    return:
+      type: number
+      desc: Sum of a and b
+
+  - name: test.info
+    desc: Get info
+    return:
+      type: object
+      fields:
+        - name: version
+          type: string
+        - name: count
+          type: number
+`
+
+const testRuntimeYAML = `
+group: objects
+type: js_object
+entries:
+  - name: log
+    desc: Logging utility
+    methods:
+      - name: Info
+        desc: Log at info level
+        args:
+          - name: message
+            type: string
+            required: true
+        return:
+          type: void
+      - name: Error
+        desc: Log at error level
+        args:
+          - name: message
+            type: string
+            required: true
+        return:
+          type: void
+`
+
+const testClassYAML = `
+group: objects
+type: js_class
+entries:
+  - name: FS
+    desc: File system operations
+    args:
+      - name: name
+        type: string
+        desc: FS engine name
+    methods:
+      - name: ReadFile
+        desc: Read file content
+        args:
+          - name: path
+            type: string
+            required: true
+        return:
+          type: string
+`
+
+const testFunctionYAML = `
+group: functions
+type: js_function
+entries:
+  - name: Process
+    desc: Execute a Yao process
+    args:
+      - name: name
+        type: string
+        required: true
+      - name: args
+        type: any
+    return:
+      type: any
+`
+
+const testWildcardYAML = `
+group: models
+type: process
+entries:
+  - name: find
+    desc: Find a record by ID
+    args:
+      - name: id
+        type: any
+        required: true
+    return:
+      type: object
+`
+
+const testUnionYAML = `
+group: stores
+type: process
+entries:
+  - name: get
+    desc: Get value by key
+    args:
+      - name: key
+        type: string
+        required: true
+    return:
+      type: union
+      desc: Stored value or null
+      variants:
+        - type: any
+          desc: The stored value
+        - type: "null"
+          desc: Key does not exist
+`
+
+func setup(t *testing.T) {
+	t.Helper()
+	Reset()
+	if err := LoadYAML([]byte(testYAML)); err != nil {
+		t.Fatalf("LoadYAML failed: %v", err)
+	}
+}
+
+func TestLoadYAML(t *testing.T) {
+	setup(t)
+
+	all := All()
+	if len(all) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(all))
+	}
+
+	e, ok := Get(TypeProcess, "test.hello")
+	if !ok {
+		t.Fatal("test.hello not found")
+	}
+	if e.Desc != "Say hello" {
+		t.Errorf("desc = %q, want %q", e.Desc, "Say hello")
+	}
+	if e.Group != "test" {
+		t.Errorf("group = %q, want %q", e.Group, "test")
+	}
+	if len(e.Args) != 1 {
+		t.Fatalf("args len = %d, want 1", len(e.Args))
+	}
+	if e.Args[0].Type != "string" {
+		t.Errorf("arg type = %q, want %q", e.Args[0].Type, "string")
+	}
+	if e.Return == nil || e.Return.Type != "string" {
+		t.Error("return type should be string")
+	}
+}
+
+func TestLoadYAML_GroupTypeInheritance(t *testing.T) {
+	Reset()
+	yaml := `
+group: mygroup
+type: process
+entries:
+  - name: mygroup.action
+    desc: Some action
+`
+	if err := LoadYAML([]byte(yaml)); err != nil {
+		t.Fatal(err)
+	}
+	e, ok := Get(TypeProcess, "mygroup.action")
+	if !ok {
+		t.Fatal("entry not found")
+	}
+	if e.Group != "mygroup" {
+		t.Errorf("group = %q, want %q", e.Group, "mygroup")
+	}
+	if e.Type != TypeProcess {
+		t.Errorf("type = %q, want %q", e.Type, TypeProcess)
+	}
+}
+
+func TestLoadYAML_InvalidYAML(t *testing.T) {
+	Reset()
+	err := LoadYAML([]byte("{{invalid yaml"))
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+}
+
+func TestRegister(t *testing.T) {
+	Reset()
+	Register(&Entry{
+		Name:  "manual.entry",
+		Type:  TypeProcess,
+		Group: "manual",
+		Desc:  "Manual registration",
+	})
+
+	e, ok := Get(TypeProcess, "manual.entry")
+	if !ok {
+		t.Fatal("manual.entry not found")
+	}
+	if e.Desc != "Manual registration" {
+		t.Errorf("desc = %q", e.Desc)
+	}
+}
+
+func TestGet_CaseInsensitive(t *testing.T) {
+	setup(t)
+
+	e, ok := Get(TypeProcess, "TEST.HELLO")
+	if !ok {
+		t.Fatal("case-insensitive Get failed")
+	}
+	if e.Name != "test.hello" {
+		t.Errorf("name = %q", e.Name)
+	}
+}
+
+func TestList(t *testing.T) {
+	setup(t)
+
+	entries := List(TypeProcess)
+	if len(entries) != 3 {
+		t.Fatalf("List returned %d entries, want 3", len(entries))
+	}
+
+	filtered := List(TypeProcess, ListOption{Group: "test"})
+	if len(filtered) != 3 {
+		t.Errorf("group filter returned %d, want 3", len(filtered))
+	}
+
+	filtered = List(TypeProcess, ListOption{Group: "nonexistent"})
+	if len(filtered) != 0 {
+		t.Errorf("nonexistent group returned %d, want 0", len(filtered))
+	}
+}
+
+func TestList_Search(t *testing.T) {
+	setup(t)
+
+	results := List(TypeProcess, ListOption{Search: "hello"})
+	if len(results) != 1 {
+		t.Fatalf("search 'hello' returned %d, want 1", len(results))
+	}
+	if results[0].Name != "test.hello" {
+		t.Errorf("name = %q", results[0].Name)
+	}
+}
+
+func TestList_Sorted(t *testing.T) {
+	setup(t)
+
+	entries := List(TypeProcess)
+	for i := 1; i < len(entries); i++ {
+		if entries[i-1].Name > entries[i].Name {
+			t.Errorf("not sorted: %s > %s", entries[i-1].Name, entries[i].Name)
+		}
+	}
+}
+
+func TestValidate_Found(t *testing.T) {
+	setup(t)
+
+	r := Validate(TypeProcess, "test.hello")
+	if !r.Valid {
+		t.Fatal("expected valid")
+	}
+	if r.Status != "ok" {
+		t.Errorf("status = %q", r.Status)
+	}
+	if r.Entry == nil {
+		t.Fatal("expected entry")
+	}
+}
+
+func TestValidate_NotFound(t *testing.T) {
+	setup(t)
+
+	r := Validate(TypeProcess, "nonexistent.process")
+	if r.Valid {
+		t.Fatal("expected not valid")
+	}
+	if r.Status != "not_found" {
+		t.Errorf("status = %q", r.Status)
+	}
+}
+
+func TestValidate_FuzzySuggestions(t *testing.T) {
+	setup(t)
+
+	r := Validate(TypeProcess, "test.hell")
+	if r.Valid {
+		t.Fatal("expected not valid")
+	}
+	if len(r.Suggestion) == 0 {
+		t.Error("expected suggestions")
+	}
+	found := false
+	for _, s := range r.Suggestion {
+		if s == "test.hello" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected test.hello in suggestions, got %v", r.Suggestion)
+	}
+}
+
+func TestSearch(t *testing.T) {
+	setup(t)
+
+	results := Search("add")
+	if len(results) != 1 {
+		t.Fatalf("search 'add' returned %d, want 1", len(results))
+	}
+	if results[0].Name != "test.add" {
+		t.Errorf("name = %q", results[0].Name)
+	}
+
+	results = Search("zzz")
+	if len(results) != 0 {
+		t.Errorf("search 'zzz' returned %d, want 0", len(results))
+	}
+}
+
+func TestGroups(t *testing.T) {
+	setup(t)
+
+	groups := Groups(TypeProcess)
+	if len(groups) != 1 || groups[0] != "test" {
+		t.Errorf("groups = %v, want [test]", groups)
+	}
+}
+
+func TestStats(t *testing.T) {
+	setup(t)
+
+	stats := Stats()
+	si, ok := stats[TypeProcess]
+	if !ok {
+		t.Fatal("no stats for process type")
+	}
+	if si.Total != 3 {
+		t.Errorf("total = %d, want 3", si.Total)
+	}
+	if si.Documented != 3 {
+		t.Errorf("documented = %d, want 3", si.Documented)
+	}
+}
+
+func TestRuntimeTypes(t *testing.T) {
+	Reset()
+	if err := LoadYAML([]byte(testRuntimeYAML)); err != nil {
+		t.Fatal(err)
+	}
+
+	entries := List(TypeJSObject)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 js_object, got %d", len(entries))
+	}
+	if entries[0].Name != "log" {
+		t.Errorf("name = %q", entries[0].Name)
+	}
+	if len(entries[0].Methods) != 2 {
+		t.Errorf("methods = %d, want 2", len(entries[0].Methods))
+	}
+}
+
+func TestClassType(t *testing.T) {
+	Reset()
+	if err := LoadYAML([]byte(testClassYAML)); err != nil {
+		t.Fatal(err)
+	}
+
+	e, ok := Get(TypeJSClass, "FS")
+	if !ok {
+		t.Fatal("FS not found")
+	}
+	if len(e.Args) != 1 {
+		t.Errorf("constructor args = %d", len(e.Args))
+	}
+	if len(e.Methods) != 1 {
+		t.Errorf("methods = %d", len(e.Methods))
+	}
+	if e.Methods[0].Name != "ReadFile" {
+		t.Errorf("method name = %q", e.Methods[0].Name)
+	}
+}
+
+func TestFunctionType(t *testing.T) {
+	Reset()
+	if err := LoadYAML([]byte(testFunctionYAML)); err != nil {
+		t.Fatal(err)
+	}
+
+	entries := List(TypeJSFunction)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1, got %d", len(entries))
+	}
+	if entries[0].Name != "Process" {
+		t.Errorf("name = %q", entries[0].Name)
+	}
+}
+
+func TestUnionReturn(t *testing.T) {
+	Reset()
+	if err := LoadYAML([]byte(testUnionYAML)); err != nil {
+		t.Fatal(err)
+	}
+
+	e, ok := Get(TypeProcess, "stores.get")
+	if !ok {
+		t.Fatal("stores.get not found")
+	}
+	if e.Return == nil {
+		t.Fatal("expected return")
+	}
+	if e.Return.Type != "union" {
+		t.Errorf("return type = %q, want union", e.Return.Type)
+	}
+	if len(e.Return.Variants) != 2 {
+		t.Errorf("variants = %d, want 2", len(e.Return.Variants))
+	}
+}
+
+func TestObjectFields(t *testing.T) {
+	setup(t)
+
+	e, ok := Get(TypeProcess, "test.info")
+	if !ok {
+		t.Fatal("test.info not found")
+	}
+	if e.Return == nil {
+		t.Fatal("expected return")
+	}
+	if e.Return.Type != "object" {
+		t.Errorf("return type = %q", e.Return.Type)
+	}
+	if len(e.Return.Fields) != 2 {
+		t.Errorf("fields = %d, want 2", len(e.Return.Fields))
+	}
+}
+
+func TestMultipleLoadYAML(t *testing.T) {
+	Reset()
+	if err := LoadYAML([]byte(testYAML)); err != nil {
+		t.Fatal(err)
+	}
+	if err := LoadYAML([]byte(testRuntimeYAML)); err != nil {
+		t.Fatal(err)
+	}
+	if err := LoadYAML([]byte(testFunctionYAML)); err != nil {
+		t.Fatal(err)
+	}
+
+	all := All()
+	if len(all) != 5 {
+		t.Errorf("expected 5 entries total, got %d", len(all))
+	}
+
+	stats := Stats()
+	if _, ok := stats[TypeProcess]; !ok {
+		t.Error("missing process stats")
+	}
+	if _, ok := stats[TypeJSObject]; !ok {
+		t.Error("missing js_object stats")
+	}
+	if _, ok := stats[TypeJSFunction]; !ok {
+		t.Error("missing js_function stats")
+	}
+}
+
+func TestLevenshtein(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"a", "", 1},
+		{"", "a", 1},
+		{"kitten", "sitting", 3},
+		{"hello", "hello", 0},
+	}
+	for _, tt := range tests {
+		got := levenshtein(tt.a, tt.b)
+		if got != tt.want {
+			t.Errorf("levenshtein(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestCallableName(t *testing.T) {
+	tests := []struct {
+		entry *Entry
+		want  string
+	}{
+		{&Entry{Name: "models.find", Type: TypeProcess, Group: "models"}, "models.<id>.find"},
+		{&Entry{Name: "stores.get", Type: TypeProcess, Group: "stores"}, "stores.<id>.get"},
+		{&Entry{Name: "http.get", Type: TypeProcess, Group: "http"}, "http.get"},
+		{&Entry{Name: "encoding.base64.Encode", Type: TypeProcess, Group: "encoding"}, "encoding.base64.Encode"},
+		{&Entry{Name: "console", Type: TypeJSObject, Group: "global"}, "console"},
+	}
+	for _, tt := range tests {
+		got := CallableName(tt.entry)
+		if got != tt.want {
+			t.Errorf("CallableName(%q, group=%q) = %q, want %q", tt.entry.Name, tt.entry.Group, got, tt.want)
+		}
+	}
+}
+
+func TestCallableToHandler(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"models.user.find", "models.find"},
+		{"models.user.pet.Find", "models.find"},
+		{"stores.cache.get", "stores.get"},
+		{"http.get", ""},
+		{"encoding.base64.Encode", ""},
+	}
+	for _, tt := range tests {
+		got := callableToHandler(tt.name)
+		if got != tt.want {
+			t.Errorf("callableToHandler(%q) = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestGetByCallableName(t *testing.T) {
+	setup(t)
+	Register(&Entry{Name: "models.find", Type: TypeProcess, Group: "models", Desc: "Find a record"})
+	e, ok := Get(TypeProcess, "models.user.find")
+	if !ok {
+		t.Fatal("expected Get to resolve models.user.find → models.find")
+	}
+	if e.Name != "models.find" {
+		t.Errorf("expected entry name models.find, got %s", e.Name)
+	}
+}
+
+func TestReset(t *testing.T) {
+	setup(t)
+	if len(All()) == 0 {
+		t.Fatal("expected entries before reset")
+	}
+	Reset()
+	if len(All()) != 0 {
+		t.Fatal("expected 0 entries after reset")
+	}
+}

--- a/doc/loader.go
+++ b/doc/loader.go
@@ -1,0 +1,62 @@
+package doc
+
+import (
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// DynamicIDGroups lists groups whose process.make() uses group.<id>.method
+// addressing. The handler key in process.Handlers is "group.method" (without
+// <id>), but users call them as "group.<id>.method".
+//
+// Exported so that CLI layers can build the callable pattern for display.
+var DynamicIDGroups = map[string]bool{
+	"models": true, "schemas": true, "stores": true,
+	"fs": true, "tasks": true, "schedules": true,
+}
+
+// LoadYAML unmarshals embedded YAML data and registers all entries.
+// Process entry names are normalised to match the handler key stored in
+// process.Handlers (gou/process/process.go RegisterGroup):
+//
+//	group="models", name="find"   → "models.find"  (handler key)
+//	group="http",   name="get"    → "http.get"     (handler key)
+//	group="encoding", name="encoding.base64.Encode" → unchanged
+func LoadYAML(data []byte) error {
+	var file DocFile
+	if err := yaml.Unmarshal(data, &file); err != nil {
+		return err
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	for i := range file.Entries {
+		entry := &file.Entries[i]
+		if entry.Type == "" {
+			entry.Type = file.Type
+		}
+		if entry.Group == "" {
+			entry.Group = file.Group
+		}
+		if entry.Type == TypeProcess {
+			entry.Name = normaliseProcessName(entry.Group, entry.Name)
+		}
+		entries[entryKey(entry.Type, entry.Name)] = entry
+	}
+	return nil
+}
+
+// normaliseProcessName ensures the entry name matches the handler key
+// stored in process.Handlers after RegisterGroup.
+//
+//	group="models", name="find"                      → "models.find"
+//	group="http",   name="get"                       → "http.get"
+//	group="utils",  name="throw.Forbidden"           → "utils.throw.Forbidden"
+//	group="encoding", name="encoding.base64.Encode"  → unchanged (already prefixed)
+func normaliseProcessName(group, name string) string {
+	prefix := strings.ToLower(group) + "."
+	if strings.HasPrefix(strings.ToLower(name), prefix) {
+		return name
+	}
+	return group + "." + name
+}

--- a/doc/query.go
+++ b/doc/query.go
@@ -1,0 +1,220 @@
+package doc
+
+import (
+	"sort"
+	"strings"
+)
+
+// List returns entries of the given type, optionally filtered.
+func List(entryType EntryType, opts ...ListOption) []*Entry {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	var opt ListOption
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+
+	out := make([]*Entry, 0)
+	for _, e := range entries {
+		if e.Type != entryType {
+			continue
+		}
+		if opt.Group != "" && !strings.EqualFold(e.Group, opt.Group) {
+			continue
+		}
+		if opt.Search != "" && !containsFold(e, opt.Search) {
+			continue
+		}
+		out = append(out, e)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Group != out[j].Group {
+			return out[i].Group < out[j].Group
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+// Validate checks whether a named entry of the given type is documented.
+// For process entries it also resolves callable names like "models.user.find"
+// to their handler key "models.find" (stripping the dynamic <id> segment).
+func Validate(entryType EntryType, name string) *ValidationResult {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	key := entryKey(entryType, name)
+	if e, ok := entries[key]; ok {
+		return &ValidationResult{
+			Valid:   true,
+			Status:  "ok",
+			Name:    name,
+			Message: "Documented",
+			Entry:   e,
+		}
+	}
+
+	// For process type, try resolving callable name → handler key.
+	if entryType == TypeProcess {
+		if hk := callableToHandler(name); hk != "" {
+			key2 := entryKey(entryType, hk)
+			if e, ok := entries[key2]; ok {
+				return &ValidationResult{
+					Valid:   true,
+					Status:  "ok",
+					Name:    name,
+					Message: "Documented",
+					Entry:   e,
+				}
+			}
+		}
+	}
+
+	// case-insensitive scan
+	lower := strings.ToLower(name)
+	for k, e := range entries {
+		if e.Type != entryType {
+			continue
+		}
+		parts := strings.SplitN(k, ":", 2)
+		if len(parts) == 2 && parts[1] == lower {
+			return &ValidationResult{
+				Valid:   true,
+				Status:  "ok",
+				Name:    name,
+				Message: "Documented",
+				Entry:   e,
+			}
+		}
+	}
+
+	// fuzzy suggestions
+	suggestions := fuzzyMatch(entryType, name)
+	return &ValidationResult{
+		Valid:      false,
+		Status:     "not_found",
+		Name:       name,
+		Message:    "No documentation found",
+		Suggestion: suggestions,
+	}
+}
+
+// Search returns entries whose name or description contains the keyword.
+func Search(keyword string) []*Entry {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	out := make([]*Entry, 0)
+	for _, e := range entries {
+		if containsFold(e, keyword) {
+			out = append(out, e)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// Groups returns a sorted list of distinct group names for the given type.
+func Groups(entryType EntryType) []string {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	seen := map[string]bool{}
+	for _, e := range entries {
+		if e.Type == entryType && e.Group != "" {
+			seen[e.Group] = true
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for g := range seen {
+		out = append(out, g)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Stats returns documentation coverage statistics keyed by EntryType.
+func Stats() map[EntryType]*StatInfo {
+	mu.RLock()
+	defer mu.RUnlock()
+
+	m := map[EntryType]*StatInfo{}
+	for _, e := range entries {
+		si, ok := m[e.Type]
+		if !ok {
+			si = &StatInfo{}
+			m[e.Type] = si
+		}
+		si.Total++
+		si.Documented++
+	}
+	return m
+}
+
+func containsFold(e *Entry, kw string) bool {
+	kw = strings.ToLower(kw)
+	return strings.Contains(strings.ToLower(e.Name), kw) ||
+		strings.Contains(strings.ToLower(e.Desc), kw) ||
+		strings.Contains(strings.ToLower(e.Group), kw)
+}
+
+func fuzzyMatch(entryType EntryType, name string) []string {
+	lower := strings.ToLower(name)
+	var suggestions []string
+	for _, e := range entries {
+		if e.Type != entryType {
+			continue
+		}
+		eName := strings.ToLower(e.Name)
+		if strings.Contains(eName, lower) || strings.Contains(lower, eName) {
+			suggestions = append(suggestions, e.Name)
+		} else if levenshtein(lower, eName) <= 3 {
+			suggestions = append(suggestions, e.Name)
+		}
+		if len(suggestions) >= 5 {
+			break
+		}
+	}
+	return suggestions
+}
+
+func levenshtein(a, b string) int {
+	la, lb := len(a), len(b)
+	if la == 0 {
+		return lb
+	}
+	if lb == 0 {
+		return la
+	}
+	prev := make([]int, lb+1)
+	curr := make([]int, lb+1)
+	for j := 0; j <= lb; j++ {
+		prev[j] = j
+	}
+	for i := 1; i <= la; i++ {
+		curr[0] = i
+		for j := 1; j <= lb; j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min3(curr[j-1]+1, prev[j]+1, prev[j-1]+cost)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[lb]
+}
+
+func min3(a, b, c int) int {
+	if a < b {
+		if a < c {
+			return a
+		}
+		return c
+	}
+	if b < c {
+		return b
+	}
+	return c
+}

--- a/doc/registry.go
+++ b/doc/registry.go
@@ -1,0 +1,74 @@
+package doc
+
+import (
+	"strings"
+	"sync"
+)
+
+var (
+	entries = map[string]*Entry{}
+	mu      sync.RWMutex
+)
+
+func entryKey(t EntryType, name string) string {
+	return string(t) + ":" + strings.ToLower(name)
+}
+
+// Register manually registers a single entry.
+func Register(entry *Entry) {
+	mu.Lock()
+	defer mu.Unlock()
+	entries[entryKey(entry.Type, entry.Name)] = entry
+}
+
+// Get retrieves a single entry by type and name (case-insensitive).
+// For process entries it also resolves callable names like "models.user.find"
+// to the handler key "models.find".
+func Get(t EntryType, name string) (*Entry, bool) {
+	mu.RLock()
+	defer mu.RUnlock()
+	if e, ok := entries[entryKey(t, name)]; ok {
+		return e, ok
+	}
+	if t == TypeProcess {
+		if hk := callableToHandler(name); hk != "" {
+			if e, ok := entries[entryKey(t, hk)]; ok {
+				return e, ok
+			}
+		}
+	}
+	return nil, false
+}
+
+// callableToHandler converts "models.user.find" → "models.find" for
+// dynamic-ID groups. Returns "" if not applicable.
+func callableToHandler(name string) string {
+	parts := strings.Split(name, ".")
+	if len(parts) < 3 {
+		return ""
+	}
+	group := strings.ToLower(parts[0])
+	if !DynamicIDGroups[group] {
+		return ""
+	}
+	method := parts[len(parts)-1]
+	return group + "." + strings.ToLower(method)
+}
+
+// All returns a snapshot of every registered entry.
+func All() []*Entry {
+	mu.RLock()
+	defer mu.RUnlock()
+	out := make([]*Entry, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e)
+	}
+	return out
+}
+
+// Reset clears all registered entries (testing only).
+func Reset() {
+	mu.Lock()
+	defer mu.Unlock()
+	entries = map[string]*Entry{}
+}

--- a/doc/types.go
+++ b/doc/types.go
@@ -1,0 +1,88 @@
+package doc
+
+// EntryType identifies the kind of documented item.
+type EntryType string
+
+const (
+	TypeProcess    EntryType = "process"
+	TypeJSObject   EntryType = "js_object"
+	TypeJSFunction EntryType = "js_function"
+	TypeJSClass    EntryType = "js_class"
+	TypeOpenAPI    EntryType = "openapi"
+)
+
+// TypeValue is the universal value descriptor used for arguments, return
+// values, fields and method signatures. Its Type field follows the bridge.go
+// Go↔JS mapping:
+//
+//	Base:     null, undefined, bool, number, bigint, string, object, array,
+//	          bytes, error, function, promise, external
+//	Extended: void, any, union
+//	Named:    Response, Paginated, CodeBlock, … (object with fields)
+type TypeValue struct {
+	Type     string      `json:"type"               yaml:"type"`
+	Desc     string      `json:"desc,omitempty"     yaml:"desc,omitempty"`
+	Example  any         `json:"example,omitempty"  yaml:"example,omitempty"`
+	Fields   []TypeValue `json:"fields,omitempty"   yaml:"fields,omitempty"`
+	Items    *TypeValue  `json:"items,omitempty"    yaml:"items,omitempty"`
+	Variants []TypeValue `json:"variants,omitempty" yaml:"variants,omitempty"`
+	Name     string      `json:"name,omitempty"     yaml:"name,omitempty"`
+	Required bool        `json:"required,omitempty" yaml:"required,omitempty"`
+}
+
+// Method describes a method on a JS object or class.
+type Method struct {
+	Name   string      `json:"name"              yaml:"name"`
+	Desc   string      `json:"desc"              yaml:"desc"`
+	Args   []TypeValue `json:"args,omitempty"    yaml:"args,omitempty"`
+	Return *TypeValue  `json:"return,omitempty"  yaml:"return,omitempty"`
+}
+
+// Endpoint describes an HTTP API endpoint (reserved for OpenAPI).
+type Endpoint struct {
+	Method string `json:"method"            yaml:"method"`
+	Path   string `json:"path"              yaml:"path"`
+	Guard  string `json:"guard,omitempty"   yaml:"guard,omitempty"`
+}
+
+// Entry is a single documentation item.
+type Entry struct {
+	Name     string      `json:"name"               yaml:"name"`
+	Type     EntryType   `json:"type"               yaml:"type"`
+	Group    string      `json:"group"              yaml:"group"`
+	Desc     string      `json:"desc"               yaml:"desc"`
+	Args     []TypeValue `json:"args,omitempty"     yaml:"args,omitempty"`
+	Return   *TypeValue  `json:"return,omitempty"   yaml:"return,omitempty"`
+	Methods  []Method    `json:"methods,omitempty"  yaml:"methods,omitempty"`
+	Endpoint *Endpoint   `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
+}
+
+// DocFile is the top-level structure of a doc.yml file.
+type DocFile struct {
+	Group   string    `yaml:"group"`
+	Type    EntryType `yaml:"type"`
+	Entries []Entry   `yaml:"entries"`
+}
+
+// ValidationResult holds the outcome of a Validate call.
+type ValidationResult struct {
+	Valid      bool     `json:"valid"`
+	Status     string   `json:"status"`
+	Name       string   `json:"name"`
+	Suggestion []string `json:"suggestion,omitempty"`
+	Message    string   `json:"message"`
+	Entry      *Entry   `json:"entry,omitempty"`
+}
+
+// ListOption controls filtering for List calls.
+type ListOption struct {
+	Group  string
+	Search string
+}
+
+// StatInfo holds documentation coverage statistics for one EntryType.
+type StatInfo struct {
+	Total        int `json:"total"`
+	Documented   int `json:"documented"`
+	Undocumented int `json:"undocumented"`
+}

--- a/encoding/doc.go
+++ b/encoding/doc.go
@@ -1,0 +1,11 @@
+package encoding
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/encoding/doc.yml
+++ b/encoding/doc.yml
@@ -1,0 +1,134 @@
+group: encoding
+type: process
+entries:
+  - name: encoding.base64.Encode
+    desc: Encode data to a base64 string
+    args:
+      - name: data
+        type: any
+        required: true
+        desc: Data to encode (converted to string representation before encoding)
+    return:
+      type: string
+      desc: Base64 encoded string
+
+  - name: encoding.base64.Decode
+    desc: Decode a base64 encoded string
+    args:
+      - name: data
+        type: string
+        required: true
+        desc: Base64 encoded string to decode
+    return:
+      type: string
+      desc: Decoded string
+
+  - name: encoding.hex.Encode
+    desc: Encode data to a hexadecimal string
+    args:
+      - name: data
+        type: any
+        required: true
+        desc: Data to encode (converted to string representation before encoding)
+    return:
+      type: string
+      desc: Hexadecimal encoded string
+
+  - name: encoding.hex.Decode
+    desc: Decode a hexadecimal encoded string
+    args:
+      - name: data
+        type: string
+        required: true
+        desc: Hexadecimal encoded string to decode
+    return:
+      type: string
+      desc: Decoded string
+
+  - name: encoding.json.Encode
+    desc: Encode a value to a JSON string
+    args:
+      - name: value
+        type: any
+        required: true
+        desc: Value to encode as JSON
+    return:
+      type: string
+      desc: JSON encoded string
+
+  - name: encoding.json.Decode
+    desc: Decode a JSON string to a value
+    args:
+      - name: data
+        type: string
+        required: true
+        desc: JSON string to decode
+    return:
+      type: any
+      desc: Decoded value
+
+  - name: encoding.json.Repair
+    desc: Repair broken JSON strings
+    args:
+      - name: data
+        type: string
+        required: true
+        desc: Broken JSON string to repair
+    return:
+      type: string
+      desc: Repaired JSON string
+
+  - name: encoding.json.Parse
+    desc: Parse a JSON string with automatic repair on failure
+    args:
+      - name: data
+        type: string
+        required: true
+        desc: JSON string to parse
+    return:
+      type: any
+      desc: Parsed value
+
+  - name: encoding.yaml.Encode
+    desc: Encode a value to a YAML string
+    args:
+      - name: value
+        type: any
+        required: true
+        desc: Value to encode as YAML
+    return:
+      type: string
+      desc: YAML encoded string
+
+  - name: encoding.yaml.Decode
+    desc: Decode a YAML string to a value
+    args:
+      - name: data
+        type: string
+        required: true
+        desc: YAML string to decode
+    return:
+      type: any
+      desc: Decoded value
+
+  - name: encoding.xml.Encode
+    desc: Encode a map to an XML string
+    args:
+      - name: data
+        type: object
+        required: true
+        desc: Map of key-value pairs to encode as XML
+    return:
+      type: string
+      desc: XML encoded string wrapped in <xml> tags
+
+  - name: encoding.xml.Decode
+    desc: Decode an XML string to a map
+    args:
+      - name: data
+        type: string
+        required: true
+        desc: XML string to decode
+    return:
+      type: object
+      desc: Decoded map of key-value pairs

--- a/ffmpeg/doc.go
+++ b/ffmpeg/doc.go
@@ -1,0 +1,11 @@
+package ffmpeg
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/ffmpeg/doc.yml
+++ b/ffmpeg/doc.yml
@@ -1,0 +1,58 @@
+group: ffmpeg
+type: process
+entries:
+  - name: info
+    desc: Get media file information including duration, dimensions, codecs, and file size
+    args:
+      - name: filePath
+        type: string
+        required: true
+        desc: Path to the media file
+    return:
+      type: object
+      desc: Media file information including duration, width, height, audio_codec, etc.
+
+  - name: convert
+    desc: Convert a media file to another format
+    args:
+      - name: inputPath
+        type: string
+        required: true
+        desc: Path to the input media file
+      - name: config
+        type: object
+        required: true
+        desc: "Convert configuration: format (string, required, e.g. \"mp3\", \"wav\", \"mp4\"), output_path (string), bitrate (string, e.g. \"128k\"), sample_rate (number, e.g. 16000)"
+    return:
+      type: string
+      desc: Path to the output file
+
+  - name: extractaudio
+    desc: Extract audio track from a video file
+    args:
+      - name: inputPath
+        type: string
+        required: true
+        desc: Path to the video file
+      - name: config
+        type: object
+        required: false
+        desc: "Extract configuration: format (string, default \"mp3\"), output_path (string), bitrate (string, e.g. \"128k\"), sample_rate (number, e.g. 16000)"
+    return:
+      type: string
+      desc: Path to the extracted audio file
+
+  - name: chunkaudio
+    desc: Split audio file into chunks using silence detection
+    args:
+      - name: inputPath
+        type: string
+        required: true
+        desc: Path to the audio file
+      - name: config
+        type: object
+        required: false
+        desc: "Chunk configuration: max_duration (number, seconds, default 600), max_size (number, bytes, default 25000000), silence_threshold (number, dB, default -40), output_dir (string), format (string, default \"mp3\")"
+    return:
+      type: object
+      desc: Chunk result including chunks array, total_chunks, total_size, and output_dir

--- a/flow/doc.go
+++ b/flow/doc.go
@@ -1,0 +1,12 @@
+package flow
+
+import (
+	_ "embed"
+
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/flow/doc.yml
+++ b/flow/doc.yml
@@ -1,0 +1,13 @@
+group: flows
+type: process
+entries:
+  - name: flows.*
+    desc: Execute a loaded data flow by name, running its defined node sequence
+    args:
+      - name: args
+        type: any
+        required: false
+        desc: Variable arguments accessible as $in within the flow nodes
+    return:
+      type: any
+      desc: The flow output (formatted by the output template if defined, otherwise the accumulated node results)

--- a/fs/doc.go
+++ b/fs/doc.go
@@ -1,0 +1,11 @@
+package fs
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/fs/doc.yml
+++ b/fs/doc.yml
@@ -1,0 +1,506 @@
+group: fs
+type: process
+entries:
+  - name: readfile
+    desc: Read file content as a string
+    args:
+      - name: file
+        type: string
+        required: true
+        desc: Path to the file
+    return:
+      type: string
+      desc: File content as a string
+
+  - name: readfilebuffer
+    desc: Read file content as a byte buffer
+    args:
+      - name: file
+        type: string
+        required: true
+        desc: Path to the file
+    return:
+      type: bytes
+      desc: File content as a byte buffer
+
+  - name: writefile
+    desc: Write string content to a file, creating or overwriting it
+    args:
+      - name: file
+        type: string
+        required: true
+        desc: Path to the file
+      - name: content
+        type: string
+        required: true
+        desc: String content to write
+      - name: perm
+        type: number
+        required: false
+        desc: File permission mode (default 0777)
+    return:
+      type: number
+      desc: Number of bytes written
+
+  - name: writefilebuffer
+    desc: Write byte buffer content to a file, creating or overwriting it
+    args:
+      - name: file
+        type: string
+        required: true
+        desc: Path to the file
+      - name: content
+        type: bytes
+        required: true
+        desc: Byte buffer content to write
+      - name: perm
+        type: number
+        required: false
+        desc: File permission mode (default 0777)
+    return:
+      type: number
+      desc: Number of bytes written
+
+  - name: appendfile
+    desc: Append string content to a file
+    args:
+      - name: file
+        type: string
+        required: true
+        desc: Path to the file
+      - name: content
+        type: string
+        required: true
+        desc: String content to append
+      - name: perm
+        type: number
+        required: false
+        desc: File permission mode (default 0777)
+    return:
+      type: number
+      desc: Number of bytes written
+
+  - name: appendfilebuffer
+    desc: Append byte buffer content to a file
+    args:
+      - name: file
+        type: string
+        required: true
+        desc: Path to the file
+      - name: content
+        type: bytes
+        required: true
+        desc: Byte buffer content to append
+      - name: perm
+        type: number
+        required: false
+        desc: File permission mode (default 0777)
+    return:
+      type: number
+      desc: Number of bytes written
+
+  - name: insertfile
+    desc: Insert string content into a file at a given byte offset
+    args:
+      - name: file
+        type: string
+        required: true
+        desc: Path to the file
+      - name: offset
+        type: number
+        required: true
+        desc: Byte offset at which to insert content
+      - name: content
+        type: string
+        required: true
+        desc: String content to insert
+      - name: perm
+        type: number
+        required: false
+        desc: File permission mode (default 0777)
+    return:
+      type: number
+      desc: Number of bytes written
+
+  - name: insertfilebuffer
+    desc: Insert byte buffer content into a file at a given byte offset
+    args:
+      - name: file
+        type: string
+        required: true
+        desc: Path to the file
+      - name: offset
+        type: number
+        required: true
+        desc: Byte offset at which to insert content
+      - name: content
+        type: bytes
+        required: true
+        desc: Byte buffer content to insert
+      - name: perm
+        type: number
+        required: false
+        desc: File permission mode (default 0777)
+    return:
+      type: number
+      desc: Number of bytes written
+
+  - name: readdir
+    desc: List files and directories in a directory
+    args:
+      - name: dir
+        type: string
+        required: true
+        desc: Path to the directory
+      - name: recursive
+        type: bool
+        required: false
+        desc: Whether to list recursively (default false)
+    return:
+      type: array
+      desc: Array of file and directory paths
+
+  - name: mkdir
+    desc: Create a single directory
+    args:
+      - name: dir
+        type: string
+        required: true
+        desc: Path to the directory to create
+      - name: perm
+        type: number
+        required: false
+        desc: Directory permission mode (default 0777)
+    return:
+      type: "null"
+      desc: Returns null on success
+
+  - name: mkdirall
+    desc: Create a directory and all necessary parent directories
+    args:
+      - name: dir
+        type: string
+        required: true
+        desc: Path to the directory to create
+      - name: perm
+        type: number
+        required: false
+        desc: Directory permission mode (default 0777)
+    return:
+      type: "null"
+      desc: Returns null on success
+
+  - name: mkdirtemp
+    desc: Create a temporary directory and return its path
+    args:
+      - name: dir
+        type: string
+        required: false
+        desc: Parent directory for the temp directory (default empty)
+      - name: pattern
+        type: string
+        required: false
+        desc: Pattern for the temp directory name (default empty)
+    return:
+      type: string
+      desc: Path of the created temporary directory
+
+  - name: remove
+    desc: Remove a single file or empty directory
+    args:
+      - name: path
+        type: string
+        required: true
+        desc: Path to the file or directory to remove
+    return:
+      type: "null"
+      desc: Returns null on success
+
+  - name: removeall
+    desc: Remove a file or directory and all its contents recursively
+    args:
+      - name: path
+        type: string
+        required: true
+        desc: Path to the file or directory to remove
+    return:
+      type: "null"
+      desc: Returns null on success
+
+  - name: exists
+    desc: Check if a file or directory exists
+    args:
+      - name: path
+        type: string
+        required: true
+        desc: Path to check
+    return:
+      type: bool
+      desc: True if the path exists, false otherwise
+
+  - name: isdir
+    desc: Check if a path is a directory
+    args:
+      - name: path
+        type: string
+        required: true
+        desc: Path to check
+    return:
+      type: bool
+      desc: True if the path is a directory
+
+  - name: isfile
+    desc: Check if a path is a regular file
+    args:
+      - name: path
+        type: string
+        required: true
+        desc: Path to check
+    return:
+      type: bool
+      desc: True if the path is a regular file
+
+  - name: islink
+    desc: Check if a path is a symbolic link
+    args:
+      - name: path
+        type: string
+        required: true
+        desc: Path to check
+    return:
+      type: bool
+      desc: True if the path is a symbolic link
+
+  - name: chmod
+    desc: Change the permission mode of a file or directory
+    args:
+      - name: path
+        type: string
+        required: true
+        desc: Path to the file or directory
+      - name: perm
+        type: number
+        required: true
+        desc: New permission mode
+    return:
+      type: "null"
+      desc: Returns null on success
+
+  - name: size
+    desc: Get the size of a file in bytes
+    args:
+      - name: path
+        type: string
+        required: true
+        desc: Path to the file
+    return:
+      type: number
+      desc: File size in bytes
+
+  - name: mode
+    desc: Get the permission mode of a file or directory
+    args:
+      - name: path
+        type: string
+        required: true
+        desc: Path to the file or directory
+    return:
+      type: number
+      desc: Permission mode as a number
+
+  - name: modtime
+    desc: Get the last modification time of a file as a Unix timestamp
+    args:
+      - name: path
+        type: string
+        required: true
+        desc: Path to the file
+    return:
+      type: number
+      desc: Last modification time as a Unix timestamp (seconds)
+
+  - name: basename
+    desc: Get the last element of a path (file name with extension)
+    args:
+      - name: path
+        type: string
+        required: true
+        desc: File path
+    return:
+      type: string
+      desc: Base name of the path
+
+  - name: dirname
+    desc: Get the directory portion of a path
+    args:
+      - name: path
+        type: string
+        required: true
+        desc: File path
+    return:
+      type: string
+      desc: Directory name of the path
+
+  - name: extname
+    desc: Get the file extension of a path
+    args:
+      - name: path
+        type: string
+        required: true
+        desc: File path
+    return:
+      type: string
+      desc: File extension including the dot (e.g. ".txt")
+
+  - name: mimetype
+    desc: Get the MIME type of a file
+    args:
+      - name: path
+        type: string
+        required: true
+        desc: Path to the file
+    return:
+      type: string
+      desc: MIME type of the file (e.g. "text/plain")
+
+  - name: move
+    desc: Move or rename a file or directory
+    args:
+      - name: src
+        type: string
+        required: true
+        desc: Source path
+      - name: dst
+        type: string
+        required: true
+        desc: Destination path
+    return:
+      type: "null"
+      desc: Returns null on success
+
+  - name: moveappend
+    desc: Move source file content by appending it to the destination file
+    args:
+      - name: src
+        type: string
+        required: true
+        desc: Source file path
+      - name: dst
+        type: string
+        required: true
+        desc: Destination file path
+    return:
+      type: "null"
+      desc: Returns null on success
+
+  - name: moveinsert
+    desc: Move source file content by inserting it into the destination file at a byte offset
+    args:
+      - name: src
+        type: string
+        required: true
+        desc: Source file path
+      - name: dst
+        type: string
+        required: true
+        desc: Destination file path
+      - name: offset
+        type: number
+        required: true
+        desc: Byte offset at which to insert in the destination file
+    return:
+      type: "null"
+      desc: Returns null on success
+
+  - name: copy
+    desc: Copy a file from source to destination
+    args:
+      - name: src
+        type: string
+        required: true
+        desc: Source file path
+      - name: dst
+        type: string
+        required: true
+        desc: Destination file path
+    return:
+      type: "null"
+      desc: Returns null on success
+
+  - name: upload
+    desc: Upload a file to the storage, supports both normal and chunked uploads
+    args:
+      - name: file
+        type: object
+        required: true
+        desc: UploadFile object containing the file data and metadata
+      - name: props
+        type: object
+        required: false
+        desc: "Upload properties: accept (string, allowed MIME types), maxFilesize (string/number, e.g. \"10M\")"
+    return:
+      type: any
+      desc: File path string on completion, or an object with path, uid and progress for chunked uploads
+
+  - name: download
+    desc: Download a file from the storage, returning a readable stream and MIME type
+    args:
+      - name: file
+        type: string
+        required: true
+        desc: Path to the file to download
+    return:
+      type: object
+      desc: "Object with content (reader) and type (MIME type string)"
+
+  - name: zip
+    desc: Compress a file or directory into a zip archive
+    args:
+      - name: src
+        type: string
+        required: true
+        desc: Source file or directory path
+      - name: dst
+        type: string
+        required: true
+        desc: Destination zip file path
+    return:
+      type: "null"
+      desc: Returns null on success
+
+  - name: unzip
+    desc: Extract a zip archive to a directory
+    args:
+      - name: src
+        type: string
+        required: true
+        desc: Source zip file path
+      - name: dst
+        type: string
+        required: true
+        desc: Destination directory path
+    return:
+      type: array
+      desc: Array of extracted file paths
+
+  - name: glob
+    desc: Find files matching a glob pattern
+    args:
+      - name: pattern
+        type: string
+        required: true
+        desc: Glob pattern to match files (e.g. "*.txt", "dir/**/*.json")
+    return:
+      type: array
+      desc: Array of matching file paths relative to the storage root
+
+  - name: abs
+    desc: Get the absolute path of a file relative to the storage root
+    args:
+      - name: file
+        type: string
+        required: true
+        desc: Relative file path
+    return:
+      type: string
+      desc: Absolute file path

--- a/http/doc.go
+++ b/http/doc.go
@@ -1,0 +1,11 @@
+package http
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/http/doc.yml
+++ b/http/doc.yml
@@ -1,0 +1,202 @@
+group: http
+type: process
+entries:
+  - name: get
+    desc: Send an HTTP GET request
+    args:
+      - name: url
+        type: string
+        required: true
+        desc: Request URL
+      - name: params
+        type: any
+        required: false
+        desc: "Query parameters: object, array of key=value strings, or query string"
+      - name: headers
+        type: any
+        required: false
+        desc: "Request headers: object or array of key-value objects"
+    return:
+      type: object
+      desc: "Response object with status, data, headers, code, and message"
+
+  - name: post
+    desc: Send an HTTP POST request
+    args:
+      - name: url
+        type: string
+        required: true
+        desc: Request URL
+      - name: payload
+        type: any
+        required: false
+        desc: "Request body: object, array, string, or file path"
+      - name: files
+        type: object
+        required: false
+        desc: "Files to upload: map of field name to file path"
+      - name: params
+        type: any
+        required: false
+        desc: "Query parameters: object, array of key=value strings, or query string"
+      - name: headers
+        type: any
+        required: false
+        desc: "Request headers: object or array of key-value objects"
+    return:
+      type: object
+      desc: "Response object with status, data, headers, code, and message"
+
+  - name: put
+    desc: Send an HTTP PUT request
+    args:
+      - name: url
+        type: string
+        required: true
+        desc: Request URL
+      - name: payload
+        type: any
+        required: false
+        desc: "Request body: object, array, string, or file path"
+      - name: params
+        type: any
+        required: false
+        desc: "Query parameters: object, array of key=value strings, or query string"
+      - name: headers
+        type: any
+        required: false
+        desc: "Request headers: object or array of key-value objects"
+    return:
+      type: object
+      desc: "Response object with status, data, headers, code, and message"
+
+  - name: patch
+    desc: Send an HTTP PATCH request
+    args:
+      - name: url
+        type: string
+        required: true
+        desc: Request URL
+      - name: payload
+        type: any
+        required: false
+        desc: "Request body: object, array, string, or file path"
+      - name: params
+        type: any
+        required: false
+        desc: "Query parameters: object, array of key=value strings, or query string"
+      - name: headers
+        type: any
+        required: false
+        desc: "Request headers: object or array of key-value objects"
+    return:
+      type: object
+      desc: "Response object with status, data, headers, code, and message"
+
+  - name: delete
+    desc: Send an HTTP DELETE request
+    args:
+      - name: url
+        type: string
+        required: true
+        desc: Request URL
+      - name: payload
+        type: any
+        required: false
+        desc: "Request body: object, array, string, or file path"
+      - name: params
+        type: any
+        required: false
+        desc: "Query parameters: object, array of key=value strings, or query string"
+      - name: headers
+        type: any
+        required: false
+        desc: "Request headers: object or array of key-value objects"
+    return:
+      type: object
+      desc: "Response object with status, data, headers, code, and message"
+
+  - name: head
+    desc: Send an HTTP HEAD request
+    args:
+      - name: url
+        type: string
+        required: true
+        desc: Request URL
+      - name: payload
+        type: any
+        required: false
+        desc: "Request body: object, array, string, or file path"
+      - name: params
+        type: any
+        required: false
+        desc: "Query parameters: object, array of key=value strings, or query string"
+      - name: headers
+        type: any
+        required: false
+        desc: "Request headers: object or array of key-value objects"
+    return:
+      type: object
+      desc: "Response object with status, data, headers, code, and message"
+
+  - name: send
+    desc: Send an HTTP request with a specified method
+    args:
+      - name: method
+        type: string
+        required: true
+        desc: "HTTP method: GET, POST, PUT, HEAD, PATCH, DELETE, etc."
+      - name: url
+        type: string
+        required: true
+        desc: Request URL
+      - name: payload
+        type: any
+        required: false
+        desc: "Request body: object, array, string, or file path"
+      - name: params
+        type: any
+        required: false
+        desc: "Query parameters: object, array of key=value strings, or query string"
+      - name: headers
+        type: any
+        required: false
+        desc: "Request headers: object or array of key-value objects"
+      - name: files
+        type: array
+        required: false
+        desc: "Files to upload: array of objects with name, path, and base64 data fields"
+    return:
+      type: object
+      desc: "Response object with status, data, headers, code, and message"
+
+  - name: stream
+    desc: Send a streaming HTTP request and handle chunked responses via a callback process
+    args:
+      - name: method
+        type: string
+        required: true
+        desc: "HTTP method: GET, POST, PUT, PATCH, DELETE, etc."
+      - name: url
+        type: string
+        required: true
+        desc: Request URL
+      - name: handler
+        type: string
+        required: true
+        desc: Process name to handle each streamed data chunk
+      - name: payload
+        type: any
+        required: false
+        desc: "Request body: object, array, string, or file path"
+      - name: params
+        type: any
+        required: false
+        desc: "Query parameters: object, array of key=value strings, or query string"
+      - name: headers
+        type: any
+        required: false
+        desc: "Request headers: object or array of key-value objects"
+    return:
+      type: object
+      desc: "Response object with status, data, headers, code, and message"

--- a/json/doc.go
+++ b/json/doc.go
@@ -1,0 +1,11 @@
+package json
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/json/doc.yml
+++ b/json/doc.yml
@@ -1,0 +1,76 @@
+group: json
+type: process
+entries:
+  - name: encode
+    desc: Encode a value to a JSON string
+    args:
+      - name: value
+        type: any
+        required: true
+        desc: The value to encode as JSON
+    return:
+      type: string
+      desc: JSON encoded string
+
+  - name: decode
+    desc: Decode a JSON string into a value
+    args:
+      - name: data
+        type: string
+        required: true
+        desc: JSON string to decode
+    return:
+      type: any
+      desc: Decoded value
+
+  - name: parse
+    desc: Universal parser supporting JSON, JSONC, Yao, and YAML formats with auto-repair for broken JSON
+    args:
+      - name: data
+        type: string
+        required: true
+        desc: The data string to parse
+      - name: hint
+        type: string
+        required: false
+        desc: "Format hint (e.g. \"file.yaml\", \".json\", \"yaml\", \".yao\")"
+    return:
+      type: any
+      desc: Parsed value
+
+  - name: repair
+    desc: Repair broken JSON string
+    args:
+      - name: data
+        type: string
+        required: true
+        desc: Broken JSON string to repair
+    return:
+      type: string
+      desc: Repaired JSON string
+
+  - name: validate
+    desc: Validate data against a JSON Schema
+    args:
+      - name: data
+        type: any
+        required: true
+        desc: The data to validate
+      - name: schema
+        type: any
+        required: true
+        desc: The JSON Schema (object, JSON string, or byte array)
+    return:
+      type: any
+      desc: "Null if valid, error message string if invalid"
+
+  - name: validateschema
+    desc: Validate a JSON Schema structure itself
+    args:
+      - name: schema
+        type: any
+        required: true
+        desc: The JSON Schema to validate
+    return:
+      type: any
+      desc: "Null if valid, error message string if invalid"

--- a/mcp/jsapi/doc.go
+++ b/mcp/jsapi/doc.go
@@ -1,0 +1,11 @@
+package jsapi
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/mcp/jsapi/doc.yml
+++ b/mcp/jsapi/doc.yml
@@ -1,0 +1,158 @@
+group: objects
+type: js_class
+entries:
+  - name: MCP
+    desc: MCP (Model Context Protocol) client for AI tool calling, resource access, and prompt management
+    args:
+      - name: clientID
+        type: string
+        required: true
+        desc: ID of a registered MCP client to connect to
+    properties:
+      - name: id
+        type: string
+        desc: The client ID used to construct this instance
+    methods:
+      - name: Info
+        desc: Get information about the connected MCP client
+        args: []
+        return:
+          type: object
+          desc: Client information object
+
+      - name: Release
+        desc: Manually release the underlying Go object to free resources (recommended in try-finally blocks)
+        args: []
+        return:
+          type: undefined
+          desc: Returns undefined
+
+      - name: ListTools
+        desc: List available tools from the MCP server
+        args:
+          - name: cursor
+            type: string
+            required: false
+            desc: Pagination cursor for fetching the next page of results
+        return:
+          type: object
+          desc: "Response object with tools array and optional nextCursor"
+
+      - name: CallTool
+        desc: Call a single tool on the MCP server
+        args:
+          - name: name
+            type: string
+            required: true
+            desc: Name of the tool to call
+          - name: arguments
+            type: any
+            required: false
+            desc: Arguments to pass to the tool
+        return:
+          type: object
+          desc: "Tool call response with content array and isError flag"
+
+      - name: CallTools
+        desc: Call multiple tools sequentially on the MCP server
+        args:
+          - name: toolCalls
+            type: array
+            required: true
+            desc: "Array of tool call objects, each with name (string) and optional arguments (any)"
+        return:
+          type: object
+          desc: Response object with results array
+
+      - name: CallToolsParallel
+        desc: Call multiple tools in parallel on the MCP server
+        args:
+          - name: toolCalls
+            type: array
+            required: true
+            desc: "Array of tool call objects, each with name (string) and optional arguments (any)"
+        return:
+          type: object
+          desc: Response object with results array
+
+      - name: ListResources
+        desc: List available resources from the MCP server
+        args:
+          - name: cursor
+            type: string
+            required: false
+            desc: Pagination cursor for fetching the next page of results
+        return:
+          type: object
+          desc: "Response object with resources array and optional nextCursor"
+
+      - name: ReadResource
+        desc: Read a specific resource by URI from the MCP server
+        args:
+          - name: uri
+            type: string
+            required: true
+            desc: "Resource URI (e.g. \"customers://1\")"
+        return:
+          type: object
+          desc: Response object with contents array
+
+      - name: ListPrompts
+        desc: List available prompt templates from the MCP server
+        args:
+          - name: cursor
+            type: string
+            required: false
+            desc: Pagination cursor for fetching the next page of results
+        return:
+          type: object
+          desc: "Response object with prompts array and optional nextCursor"
+
+      - name: GetPrompt
+        desc: Get a specific prompt template with optional arguments
+        args:
+          - name: name
+            type: string
+            required: true
+            desc: Name of the prompt to retrieve
+          - name: arguments
+            type: object
+            required: false
+            desc: Key-value arguments to fill into the prompt template
+        return:
+          type: object
+          desc: Prompt response object with messages
+
+      - name: ListSamples
+        desc: List sample data for a specific item type and name
+        args:
+          - name: itemType
+            type: string
+            required: true
+            desc: "Sample item type (e.g. \"tool\", \"prompt\", \"resource\")"
+          - name: itemName
+            type: string
+            required: true
+            desc: Name of the item to list samples for
+        return:
+          type: object
+          desc: Response object with samples array and total count
+
+      - name: GetSample
+        desc: Get a specific sample by item type, name, and index
+        args:
+          - name: itemType
+            type: string
+            required: true
+            desc: "Sample item type (e.g. \"tool\", \"prompt\", \"resource\")"
+          - name: itemName
+            type: string
+            required: true
+            desc: Name of the item
+          - name: index
+            type: number
+            required: true
+            desc: Zero-based index of the sample to retrieve
+        return:
+          type: object
+          desc: Sample data object with index and content

--- a/model/doc.go
+++ b/model/doc.go
@@ -1,0 +1,17 @@
+package model
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+//go:embed doc_model.yml
+var docModelYAML []byte
+
+func init() {
+	doc.LoadYAML(docYAML)
+	doc.LoadYAML(docModelYAML)
+}

--- a/model/doc.yml
+++ b/model/doc.yml
@@ -1,0 +1,354 @@
+group: models
+type: process
+entries:
+  - name: find
+    desc: Find a single record by primary key with optional query parameters
+    args:
+      - name: id
+        type: any
+        required: true
+        desc: Primary key value of the record
+      - name: params
+        type: object
+        required: false
+        desc: Query parameters (select, withs, etc.)
+    return:
+      type: object
+      desc: The found record as a map
+
+  - name: get
+    desc: Get multiple records matching query parameters
+    args:
+      - name: params
+        type: object
+        required: true
+        desc: Query parameters (select, wheres, orders, limit, etc.)
+    return:
+      type: array
+      desc: Array of matching records
+
+  - name: paginate
+    desc: Get paginated records matching query parameters
+    args:
+      - name: params
+        type: object
+        required: true
+        desc: Query parameters (select, wheres, orders, etc.)
+      - name: page
+        type: number
+        required: true
+        desc: Page number (1-based)
+      - name: pagesize
+        type: number
+        required: true
+        desc: Number of records per page
+    return:
+      type: object
+      desc: Paginated result with data array, total, page, pagesize, etc.
+
+  - name: count
+    desc: Count records matching query parameters
+    args:
+      - name: params
+        type: object
+        required: true
+        desc: Query parameters (wheres, etc.)
+    return:
+      type: number
+      desc: Number of matching records
+
+  - name: create
+    desc: Create a new record
+    args:
+      - name: row
+        type: object
+        required: true
+        desc: Record data as key-value pairs
+    return:
+      type: any
+      desc: Primary key value of the created record
+
+  - name: update
+    desc: Update an existing record by primary key
+    args:
+      - name: id
+        type: any
+        required: true
+        desc: Primary key value of the record to update
+      - name: row
+        type: object
+        required: true
+        desc: Fields to update as key-value pairs
+    return:
+      type: "null"
+      desc: Returns null on success
+
+  - name: save
+    desc: Create or update a record (upsert by primary key)
+    args:
+      - name: row
+        type: object
+        required: true
+        desc: Record data; if primary key is present the record is updated, otherwise created
+    return:
+      type: any
+      desc: Primary key value of the saved record
+
+  - name: delete
+    desc: Soft-delete a record by primary key (sets deleted_at)
+    args:
+      - name: id
+        type: any
+        required: true
+        desc: Primary key value of the record to delete
+    return:
+      type: "null"
+      desc: Returns null on success
+
+  - name: destroy
+    desc: Hard-delete a record by primary key (permanently removes)
+    args:
+      - name: id
+        type: any
+        required: true
+        desc: Primary key value of the record to destroy
+    return:
+      type: "null"
+      desc: Returns null on success
+
+  - name: insert
+    desc: Batch insert multiple records by specifying columns and row values
+    args:
+      - name: columns
+        type: array
+        required: true
+        desc: Array of column names
+      - name: rows
+        type: array
+        required: true
+        desc: Array of row arrays, each containing values matching the columns order
+    return:
+      type: "null"
+      desc: Returns null on success
+
+  - name: updatewhere
+    desc: Update records matching query parameters
+    args:
+      - name: params
+        type: object
+        required: true
+        desc: Query parameters with wheres conditions
+      - name: row
+        type: object
+        required: true
+        desc: Fields to update as key-value pairs
+    return:
+      type: any
+      desc: Number of affected rows
+
+  - name: deletewhere
+    desc: Soft-delete records matching query parameters
+    args:
+      - name: params
+        type: object
+        required: true
+        desc: Query parameters with wheres conditions
+    return:
+      type: any
+      desc: Number of affected rows
+
+  - name: destroywhere
+    desc: Hard-delete records matching query parameters (permanently removes)
+    args:
+      - name: params
+        type: object
+        required: true
+        desc: Query parameters with wheres conditions
+    return:
+      type: any
+      desc: Number of affected rows
+
+  - name: eachsave
+    desc: Save multiple records in a batch, creating or updating each one
+    args:
+      - name: rows
+        type: array
+        required: true
+        desc: Array of record objects to save
+      - name: eachrow
+        type: object
+        required: false
+        desc: Common fields to merge into each row before saving
+    return:
+      type: array
+      desc: Array of primary key values for the saved records
+
+  - name: eachsaveafterdelete
+    desc: Delete records by IDs then batch save new records
+    args:
+      - name: ids
+        type: array
+        required: true
+        desc: Array of primary key values to delete before saving
+      - name: rows
+        type: array
+        required: true
+        desc: Array of record objects to save
+      - name: eachrow
+        type: object
+        required: false
+        desc: Common fields to merge into each row before saving
+    return:
+      type: array
+      desc: Array of primary key values for the saved records
+
+  - name: upsert
+    desc: Insert or update a record based on unique column constraints
+    args:
+      - name: row
+        type: object
+        required: true
+        desc: Record data as key-value pairs
+      - name: uniqueBy
+        type: any
+        required: true
+        desc: Column name (string) or array of column names used to determine uniqueness
+      - name: updateColumns
+        type: array
+        required: false
+        desc: Array of column names to update on conflict; if omitted, all columns are updated
+    return:
+      type: any
+      desc: Primary key value of the upserted record
+
+  - name: selectoption
+    desc: "[Deprecated] Get select options matching a keyword search"
+    args:
+      - name: keyword
+        type: string
+        required: false
+        desc: Search keyword (default matches all)
+      - name: name
+        type: string
+        required: false
+        desc: "Column to use as the option label (default: \"name\")"
+      - name: value
+        type: string
+        required: false
+        desc: "Column to use as the option value (default: \"id\")"
+      - name: limit
+        type: number
+        required: false
+        desc: "Maximum number of results (default: 20)"
+    return:
+      type: array
+      desc: Array of objects with name and id fields
+
+  - name: takesnapshot
+    desc: Create a snapshot (backup copy) of the model's table
+    args:
+      - name: inMemory
+        type: bool
+        required: true
+        desc: Whether to create the snapshot table in memory
+    return:
+      type: string
+      desc: Name of the created snapshot table
+
+  - name: restoresnapshot
+    desc: Restore the model's table data from a snapshot
+    args:
+      - name: name
+        type: string
+        required: true
+        desc: Name of the snapshot table to restore from
+    return:
+      type: "null"
+      desc: Returns null on success
+
+  - name: restoresnapshotbyrename
+    desc: Restore the model's table from a snapshot by renaming tables
+    args:
+      - name: name
+        type: string
+        required: true
+        desc: Name of the snapshot table to restore from
+    return:
+      type: "null"
+      desc: Returns null on success
+
+  - name: dropsnapshot
+    desc: Drop a snapshot table
+    args:
+      - name: name
+        type: string
+        required: true
+        desc: Name of the snapshot table to drop
+    return:
+      type: "null"
+      desc: Returns null on success
+
+  - name: snapshotexists
+    desc: Check if a snapshot table exists
+    args:
+      - name: name
+        type: string
+        required: true
+        desc: Name of the snapshot table to check
+    return:
+      type: bool
+      desc: True if the snapshot table exists
+
+  - name: migrate
+    desc: Run database migration for the model
+    args:
+      - name: force
+        type: bool
+        required: false
+        desc: Whether to force migration (default false)
+    return:
+      type: any
+      desc: Migration result
+
+  - name: load
+    desc: Load a model from a DSL file or source string
+    args:
+      - name: file
+        type: string
+        required: true
+        desc: Path to the model DSL file
+      - name: source
+        type: string
+        required: false
+        desc: Model DSL source string; if provided, file is used as the file path reference
+    return:
+      type: any
+      desc: Error on failure, null on success
+
+  - name: reload
+    desc: Reload the model from its original source
+    args: []
+    return:
+      type: "null"
+      desc: Returns null on success
+
+  - name: metadata
+    desc: Get the model metadata including table schema information
+    args: []
+    return:
+      type: object
+      desc: Model metadata object
+
+  - name: read
+    desc: Read the model DSL source as a string
+    args: []
+    return:
+      type: string
+      desc: The model DSL source content
+
+  - name: exists
+    desc: Check if the model is loaded
+    args: []
+    return:
+      type: bool
+      desc: True if the model is loaded

--- a/model/doc_model.yml
+++ b/model/doc_model.yml
@@ -1,0 +1,98 @@
+group: model
+type: process
+entries:
+  - name: list
+    desc: List all loaded models with optional metadata and columns
+    args:
+      - name: options
+        type: object
+        required: false
+        desc: "Options: metadata (bool) to include full metadata, columns (bool) to include column definitions"
+    return:
+      type: array
+      desc: Array of model info objects with id, name, description, file, table, primary fields
+
+  - name: read
+    desc: Read a model's DSL source by model ID
+    args: []
+    return:
+      type: string
+      desc: The model DSL source content
+
+  - name: dsl
+    desc: Get model DSL information including table and primary key details
+    args:
+      - name: id
+        type: string
+        required: true
+        desc: Model ID
+      - name: options
+        type: object
+        required: false
+        desc: "Options: metadata (bool) to include full metadata, columns (bool) to include column definitions"
+    return:
+      type: object
+      desc: Model DSL object with id, name, description, file, table, primary fields
+
+  - name: exists
+    desc: Check if a model is loaded by model ID
+    args:
+      - name: id
+        type: string
+        required: true
+        desc: Model ID to check
+    return:
+      type: bool
+      desc: True if the model is loaded
+
+  - name: reload
+    desc: Reload a model by model ID
+    args:
+      - name: id
+        type: string
+        required: true
+        desc: Model ID to reload
+    return:
+      type: "null"
+      desc: Returns null on success
+
+  - name: migrate
+    desc: Migrate a model by model ID
+    args:
+      - name: id
+        type: string
+        required: true
+        desc: Model ID to migrate
+      - name: force
+        type: bool
+        required: false
+        desc: Whether to force migration (default false)
+    return:
+      type: any
+      desc: Migration result
+
+  - name: load
+    desc: Load a model from a DSL source string by model ID
+    args:
+      - name: id
+        type: string
+        required: true
+        desc: Model ID to assign
+      - name: source
+        type: string
+        required: true
+        desc: Model DSL source string
+    return:
+      type: any
+      desc: Error on failure, null on success
+
+  - name: unload
+    desc: Unload a model by model ID
+    args:
+      - name: id
+        type: string
+        required: true
+        desc: Model ID to unload
+    return:
+      type: "null"
+      desc: Returns null on success

--- a/office/doc.go
+++ b/office/doc.go
@@ -1,0 +1,11 @@
+package office
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/office/doc.yml
+++ b/office/doc.yml
@@ -1,0 +1,32 @@
+group: office
+type: process
+entries:
+  - name: parse
+    desc: Parse an Office document (DOCX/PPTX) from a file path, extracting markdown content and media files
+    args:
+      - name: filePath
+        type: string
+        required: true
+        desc: Path to the Office document
+      - name: config
+        type: object
+        required: false
+        desc: "Optional configuration: output_dir (string, directory for extracted media files)"
+    return:
+      type: object
+      desc: Parsed result with markdown content, metadata, and media file paths
+
+  - name: parsebytes
+    desc: Parse an Office document from base64-encoded data, extracting markdown content and media files
+    args:
+      - name: data
+        type: string
+        required: true
+        desc: Base64-encoded file content
+      - name: config
+        type: object
+        required: false
+        desc: "Optional configuration: output_dir (string, directory for extracted media files)"
+    return:
+      type: object
+      desc: Parsed result with markdown content, metadata, and media file paths

--- a/pdf/doc.go
+++ b/pdf/doc.go
@@ -1,0 +1,11 @@
+package pdf
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/pdf/doc.yml
+++ b/pdf/doc.yml
@@ -1,0 +1,43 @@
+group: pdf
+type: process
+entries:
+  - name: info
+    desc: Get PDF file information including page count, metadata, and file size
+    args:
+      - name: filePath
+        type: string
+        required: true
+        desc: Path to the PDF file
+    return:
+      type: object
+      desc: PDF file information including page_count, file_size, title, etc.
+
+  - name: split
+    desc: Split a PDF file into multiple files by page ranges
+    args:
+      - name: filePath
+        type: string
+        required: true
+        desc: Path to the PDF file
+      - name: config
+        type: object
+        required: true
+        desc: "Split configuration: pages (string, e.g. \"1-3,5,7-10\"), pages_per_file (number), output_dir (string), output_prefix (string)"
+    return:
+      type: array
+      desc: Array of file paths to the output PDF files
+
+  - name: convert
+    desc: Convert PDF pages to images (PNG/JPEG)
+    args:
+      - name: filePath
+        type: string
+        required: true
+        desc: Path to the PDF file
+      - name: config
+        type: object
+        required: false
+        desc: "Convert configuration: format (string, default \"png\"), dpi (number, default 150), pages (string, e.g. \"1-3\"), output_dir (string), output_prefix (string), quality (number, 1-100)"
+    return:
+      type: array
+      desc: Array of file paths to the output image files

--- a/plugin/doc.go
+++ b/plugin/doc.go
@@ -1,0 +1,12 @@
+package plugin
+
+import (
+	_ "embed"
+
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/plugin/doc.yml
+++ b/plugin/doc.yml
@@ -1,0 +1,13 @@
+group: plugins
+type: process
+entries:
+  - name: plugins.*.*
+    desc: Execute a method on a loaded GRPC plugin
+    args:
+      - name: args
+        type: any
+        required: false
+        desc: Variable arguments passed to the plugin method
+    return:
+      type: any
+      desc: The value returned by the plugin method

--- a/runtime/v8/doc.go
+++ b/runtime/v8/doc.go
@@ -1,0 +1,12 @@
+package v8
+
+import (
+	_ "embed"
+
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/runtime/v8/doc.yml
+++ b/runtime/v8/doc.yml
@@ -1,0 +1,13 @@
+group: scripts
+type: process
+entries:
+  - name: scripts.*.*
+    desc: Execute an exported function from a loaded JavaScript/TypeScript script
+    args:
+      - name: args
+        type: any
+        required: false
+        desc: Variable arguments passed to the script function
+    return:
+      type: any
+      desc: The value returned by the script function

--- a/runtime/v8/functions/all/doc.go
+++ b/runtime/v8/functions/all/doc.go
@@ -1,0 +1,11 @@
+package all
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/runtime/v8/functions/all/doc.yml
+++ b/runtime/v8/functions/all/doc.yml
@@ -1,0 +1,13 @@
+group: functions
+type: js_function
+entries:
+  - name: All
+    desc: Execute multiple processes concurrently and wait for all to complete (Promise.all semantics)
+    args:
+      - name: tasks
+        type: array
+        required: true
+        desc: "Array of task objects, each with: process (string, required), args (array, optional), timeout (number in seconds, optional)"
+    return:
+      type: array
+      desc: "Array of result objects ordered by task index, each with: data (return value), index (original position), and error (string, present only on failure)"

--- a/runtime/v8/functions/any/doc.go
+++ b/runtime/v8/functions/any/doc.go
@@ -1,0 +1,11 @@
+package any
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/runtime/v8/functions/any/doc.yml
+++ b/runtime/v8/functions/any/doc.yml
@@ -1,0 +1,13 @@
+group: functions
+type: js_function
+entries:
+  - name: Any
+    desc: Execute multiple processes concurrently and return once the first succeeds (Promise.any semantics)
+    args:
+      - name: tasks
+        type: array
+        required: true
+        desc: "Array of task objects, each with: process (string, required), args (array, optional), timeout (number in seconds, optional)"
+    return:
+      type: array
+      desc: "Array of result objects ordered by task index, each with: data (return value), index (original position), and error (string, present only on failure); only completed tasks have populated results"

--- a/runtime/v8/functions/atob/doc.go
+++ b/runtime/v8/functions/atob/doc.go
@@ -1,0 +1,11 @@
+package atob
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/runtime/v8/functions/atob/doc.yml
+++ b/runtime/v8/functions/atob/doc.yml
@@ -1,0 +1,13 @@
+group: functions
+type: js_function
+entries:
+  - name: atob
+    desc: Decode a Base64-encoded string to its original text representation
+    args:
+      - name: encoded
+        type: string
+        required: true
+        desc: A Base64-encoded string to decode
+    return:
+      type: string
+      desc: The decoded string

--- a/runtime/v8/functions/authorized/doc.go
+++ b/runtime/v8/functions/authorized/doc.go
@@ -1,0 +1,11 @@
+package authorized
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/runtime/v8/functions/authorized/doc.yml
+++ b/runtime/v8/functions/authorized/doc.yml
@@ -1,0 +1,8 @@
+group: functions
+type: js_function
+entries:
+  - name: Authorized
+    desc: Return the current authorization information from the runtime context
+    return:
+      type: object
+      desc: "The authorized info object, or null if no authorization is present"

--- a/runtime/v8/functions/btoa/doc.go
+++ b/runtime/v8/functions/btoa/doc.go
@@ -1,0 +1,11 @@
+package btoa
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/runtime/v8/functions/btoa/doc.yml
+++ b/runtime/v8/functions/btoa/doc.yml
@@ -1,0 +1,13 @@
+group: functions
+type: js_function
+entries:
+  - name: btoa
+    desc: Encode a string to its Base64 representation
+    args:
+      - name: data
+        type: string
+        required: true
+        desc: The string to Base64-encode
+    return:
+      type: string
+      desc: The Base64-encoded string

--- a/runtime/v8/functions/eval/doc.go
+++ b/runtime/v8/functions/eval/doc.go
@@ -1,0 +1,11 @@
+package eval
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/runtime/v8/functions/eval/doc.yml
+++ b/runtime/v8/functions/eval/doc.yml
@@ -1,0 +1,17 @@
+group: functions
+type: js_function
+entries:
+  - name: Eval
+    desc: Evaluate a JavaScript function string and execute it with the given arguments
+    args:
+      - name: source
+        type: string
+        required: true
+        desc: "JavaScript function source code to evaluate (named functions are auto-converted to arrow functions)"
+      - name: args
+        type: any
+        required: false
+        desc: "Variadic arguments passed to the evaluated function"
+    return:
+      type: any
+      desc: The return value of the evaluated function

--- a/runtime/v8/functions/lang/doc.go
+++ b/runtime/v8/functions/lang/doc.go
@@ -1,0 +1,11 @@
+package lang
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/runtime/v8/functions/lang/doc.yml
+++ b/runtime/v8/functions/lang/doc.yml
@@ -1,0 +1,13 @@
+group: functions
+type: js_function
+entries:
+  - name: $L
+    desc: Translate a string using the i18n language pack
+    args:
+      - name: message
+        type: string
+        required: true
+        desc: "The message key to translate, with optional \"::\" prefix (which is automatically stripped)"
+    return:
+      type: string
+      desc: The translated string, or the original message if no translation is found

--- a/runtime/v8/functions/process/doc.go
+++ b/runtime/v8/functions/process/doc.go
@@ -1,0 +1,11 @@
+package process
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/runtime/v8/functions/process/doc.yml
+++ b/runtime/v8/functions/process/doc.yml
@@ -1,0 +1,17 @@
+group: functions
+type: js_function
+entries:
+  - name: Process
+    desc: Execute a Yao process by name and return its result synchronously
+    args:
+      - name: name
+        type: string
+        required: true
+        desc: "Process name to execute (e.g. \"models.user.Find\", \"scripts.example.Hello\")"
+      - name: args
+        type: any
+        required: false
+        desc: "Variadic arguments passed to the process"
+    return:
+      type: any
+      desc: The return value of the executed process

--- a/runtime/v8/functions/race/doc.go
+++ b/runtime/v8/functions/race/doc.go
@@ -1,0 +1,11 @@
+package race
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/runtime/v8/functions/race/doc.yml
+++ b/runtime/v8/functions/race/doc.yml
@@ -1,0 +1,13 @@
+group: functions
+type: js_function
+entries:
+  - name: Race
+    desc: Execute multiple processes concurrently and return once the first completes, regardless of success or failure (Promise.race semantics)
+    args:
+      - name: tasks
+        type: array
+        required: true
+        desc: "Array of task objects, each with: process (string, required), args (array, optional), timeout (number in seconds, optional)"
+    return:
+      type: array
+      desc: "Array of result objects ordered by task index, each with: data (return value), index (original position), and error (string, present only on failure); only completed tasks have populated results"

--- a/runtime/v8/functions/use/doc.go
+++ b/runtime/v8/functions/use/doc.go
@@ -1,0 +1,11 @@
+package use
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/runtime/v8/functions/use/doc.yml
+++ b/runtime/v8/functions/use/doc.yml
@@ -1,0 +1,21 @@
+group: functions
+type: js_function
+entries:
+  - name: Use
+    desc: Create an instance from a constructor, pass it to a callback, and automatically release it afterward
+    args:
+      - name: Constructor
+        type: function
+        required: true
+        desc: A constructor function to instantiate with new
+      - name: args
+        type: any
+        required: false
+        desc: "Variadic arguments passed to the constructor (between Constructor and callback)"
+      - name: callback
+        type: function
+        required: true
+        desc: "Callback function receiving the instance; the instance's __release() method is called automatically after the callback completes"
+    return:
+      type: any
+      desc: The return value of the callback function

--- a/runtime/v8/objects/console/doc.go
+++ b/runtime/v8/objects/console/doc.go
@@ -1,0 +1,12 @@
+package console
+
+import (
+	_ "embed"
+
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/runtime/v8/objects/console/doc.yml
+++ b/runtime/v8/objects/console/doc.yml
@@ -1,0 +1,45 @@
+group: objects
+type: js_object
+entries:
+  - name: console
+    desc: Global console object for dumping values to output; log method only works in development mode
+    methods:
+      - name: log
+        desc: Dump values to standard output (only active in development mode, no-op in production)
+        args:
+          - name: args
+            type: any
+            required: true
+            desc: One or more values to dump
+        return:
+          type: null
+
+      - name: info
+        desc: Dump values to standard output at info level
+        args:
+          - name: args
+            type: any
+            required: true
+            desc: One or more values to dump
+        return:
+          type: null
+
+      - name: warn
+        desc: Dump values to standard output at warning level
+        args:
+          - name: args
+            type: any
+            required: true
+            desc: One or more values to dump
+        return:
+          type: null
+
+      - name: error
+        desc: Dump values to standard output at error level
+        args:
+          - name: args
+            type: any
+            required: true
+            desc: One or more values to dump
+        return:
+          type: null

--- a/runtime/v8/objects/exception/doc.go
+++ b/runtime/v8/objects/exception/doc.go
@@ -1,0 +1,12 @@
+package exception
+
+import (
+	_ "embed"
+
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/runtime/v8/objects/exception/doc.yml
+++ b/runtime/v8/objects/exception/doc.yml
@@ -1,0 +1,29 @@
+group: objects
+type: js_class
+entries:
+  - name: Exception
+    desc: Constructor for creating exception objects with a message and optional error code, extends the built-in Error
+    args:
+      - name: message
+        type: string
+        required: true
+        desc: Error message describing the exception
+      - name: code
+        type: number
+        required: false
+        desc: Numeric error code (defaults to 500 if not provided)
+    return:
+      type: object
+      desc: An Error-like object with code, message, and name properties
+    methods:
+      - name: Code
+        desc: Get the error code of this exception
+        return:
+          type: any
+          desc: The error code value
+
+      - name: Message
+        desc: Get the error message of this exception
+        return:
+          type: any
+          desc: The error message value

--- a/runtime/v8/objects/fs/doc.go
+++ b/runtime/v8/objects/fs/doc.go
@@ -1,0 +1,11 @@
+package fs
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/runtime/v8/objects/fs/doc.yml
+++ b/runtime/v8/objects/fs/doc.yml
@@ -1,0 +1,582 @@
+group: objects
+type: js_class
+entries:
+  - name: FS
+    desc: File system operations object for reading, writing, and managing files and directories
+    args:
+      - name: name
+        type: string
+        required: false
+        desc: "File system name (default: \"system\")"
+    methods:
+      - name: Exists
+        desc: Check if a file or directory exists at the given path
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: File or directory path
+        return:
+          type: bool
+          desc: True if the path exists
+
+      - name: IsDir
+        desc: Check if the given path is a directory
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: Path to check
+        return:
+          type: bool
+          desc: True if the path is a directory
+
+      - name: IsFile
+        desc: Check if the given path is a file
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: Path to check
+        return:
+          type: bool
+          desc: True if the path is a file
+
+      - name: IsLink
+        desc: Check if the given path is a symbolic link
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: Path to check
+        return:
+          type: bool
+          desc: True if the path is a symbolic link
+
+      - name: ReadFile
+        desc: Read a file and return its content as a string
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: File path to read
+        return:
+          type: string
+          desc: File content as a string
+
+      - name: ReadFileBuffer
+        desc: Read a file and return its content as a Uint8Array buffer
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: File path to read
+        return:
+          type: bytes
+          desc: File content as a Uint8Array
+
+      - name: ReadFileBase64
+        desc: Read a file and return its content as a base64-encoded string
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: File path to read
+        return:
+          type: string
+          desc: File content as a base64-encoded string
+
+      - name: ReadCloser
+        desc: Open a file and return a ReadCloser handle for streaming reads
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: File path to open
+        return:
+          type: external
+          desc: ReadCloser handle
+
+      - name: WriteFile
+        desc: Write string content to a file, creating or overwriting it
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: File path to write
+          - name: content
+            type: string
+            required: true
+            desc: String content to write
+          - name: perm
+            type: number
+            required: false
+            desc: "File permission mode (default: 0777)"
+        return:
+          type: number
+          desc: Number of bytes written
+
+      - name: WriteFileBuffer
+        desc: Write binary buffer content to a file, creating or overwriting it
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: File path to write
+          - name: data
+            type: bytes
+            required: true
+            desc: Uint8Array or ArrayBufferView data to write
+          - name: perm
+            type: number
+            required: false
+            desc: "File permission mode (default: 0777)"
+        return:
+          type: number
+          desc: Number of bytes written
+
+      - name: WriteFileBase64
+        desc: Decode a base64-encoded string and write it to a file
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: File path to write
+          - name: data
+            type: string
+            required: true
+            desc: Base64-encoded string data
+          - name: perm
+            type: number
+            required: false
+            desc: "File permission mode (default: 0777)"
+        return:
+          type: number
+          desc: Number of bytes written
+
+      - name: AppendFile
+        desc: Append string content to an existing file
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: File path to append to
+          - name: content
+            type: string
+            required: true
+            desc: String content to append
+          - name: perm
+            type: number
+            required: false
+            desc: "File permission mode (default: 0777)"
+        return:
+          type: number
+          desc: Number of bytes written
+
+      - name: AppendBuffer
+        desc: Append binary buffer content to an existing file
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: File path to append to
+          - name: data
+            type: bytes
+            required: true
+            desc: Uint8Array or ArrayBufferView data to append
+          - name: perm
+            type: number
+            required: false
+            desc: "File permission mode (default: 0777)"
+        return:
+          type: number
+          desc: Number of bytes written
+
+      - name: AppendBase64
+        desc: Decode a base64-encoded string and append it to a file
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: File path to append to
+          - name: data
+            type: string
+            required: true
+            desc: Base64-encoded string data
+          - name: perm
+            type: number
+            required: false
+            desc: "File permission mode (default: 0777)"
+        return:
+          type: number
+          desc: Number of bytes written
+
+      - name: InsertFile
+        desc: Insert string content at a byte offset in a file
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: File path
+          - name: offset
+            type: number
+            required: true
+            desc: Byte offset position to insert at
+          - name: content
+            type: string
+            required: true
+            desc: String content to insert
+          - name: perm
+            type: number
+            required: false
+            desc: "File permission mode (default: 0777)"
+        return:
+          type: number
+          desc: Number of bytes written
+
+      - name: InsertBuffer
+        desc: Insert binary buffer content at a byte offset in a file
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: File path
+          - name: offset
+            type: number
+            required: true
+            desc: Byte offset position to insert at
+          - name: data
+            type: bytes
+            required: true
+            desc: Uint8Array or ArrayBufferView data to insert
+          - name: perm
+            type: number
+            required: false
+            desc: "File permission mode (default: 0777)"
+        return:
+          type: number
+          desc: Number of bytes written
+
+      - name: InsertBase64
+        desc: Decode a base64-encoded string and insert it at a byte offset in a file
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: File path
+          - name: offset
+            type: number
+            required: true
+            desc: Byte offset position to insert at
+          - name: data
+            type: string
+            required: true
+            desc: Base64-encoded string data
+          - name: perm
+            type: number
+            required: false
+            desc: "File permission mode (default: 0777)"
+        return:
+          type: number
+          desc: Number of bytes written
+
+      - name: Remove
+        desc: Remove a single file or empty directory
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: Path to remove
+        return:
+          type: "null"
+          desc: Returns null on success
+
+      - name: RemoveAll
+        desc: Recursively remove a file or directory and all its contents
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: Path to remove recursively
+        return:
+          type: "null"
+          desc: Returns null on success
+
+      - name: Download
+        desc: Get a file for downloading, returning its MIME type and a ReadCloser
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: File path to download
+        return:
+          type: external
+          desc: "Object with type (MIME type string) and content (ReadCloser)"
+
+      - name: ReadDir
+        desc: List the contents of a directory
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: Directory path to read
+          - name: recursive
+            type: bool
+            required: false
+            desc: "Whether to read recursively (default: false)"
+        return:
+          type: array
+          desc: Array of file/directory name strings
+
+      - name: Mkdir
+        desc: Create a single directory
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: Directory path to create
+          - name: perm
+            type: number
+            required: false
+            desc: "Permission mode (default: 0777)"
+        return:
+          type: "null"
+          desc: Returns null on success
+
+      - name: MkdirAll
+        desc: Create a directory and all necessary parent directories
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: Directory path to create
+          - name: perm
+            type: number
+            required: false
+            desc: "Permission mode (default: 0777)"
+        return:
+          type: "null"
+          desc: Returns null on success
+
+      - name: MkdirTemp
+        desc: Create a temporary directory and return its path
+        args:
+          - name: dir
+            type: string
+            required: false
+            desc: "Parent directory for the temp dir (default: system temp)"
+          - name: pattern
+            type: string
+            required: false
+            desc: "Name pattern with * as random placeholder (e.g. \"*-logs\")"
+        return:
+          type: string
+          desc: Path of the created temporary directory
+
+      - name: Chmod
+        desc: Change the permission mode of a file or directory
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: File or directory path
+          - name: perm
+            type: number
+            required: true
+            desc: New permission mode (e.g. 0755)
+        return:
+          type: "null"
+          desc: Returns null on success
+
+      - name: BaseName
+        desc: Return the last element of a path (file name with extension)
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: File path
+        return:
+          type: string
+          desc: Base name of the file
+
+      - name: DirName
+        desc: Return the directory portion of a path
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: File path
+        return:
+          type: string
+          desc: Directory name
+
+      - name: ExtName
+        desc: Return the file extension of a path
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: File path
+        return:
+          type: string
+          desc: File extension (e.g. ".txt")
+
+      - name: MimeType
+        desc: Detect and return the MIME type of a file
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: File path
+        return:
+          type: string
+          desc: MIME type string (e.g. "text/plain")
+
+      - name: Mode
+        desc: Return the permission mode of a file or directory
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: File or directory path
+        return:
+          type: number
+          desc: Permission mode as an unsigned integer
+
+      - name: Size
+        desc: Return the size of a file in bytes
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: File path
+        return:
+          type: number
+          desc: File size in bytes
+
+      - name: ModTime
+        desc: Return the last modification time of a file as a Unix timestamp
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: File path
+        return:
+          type: number
+          desc: Last modification time as Unix timestamp (seconds)
+
+      - name: Move
+        desc: Move or rename a file or directory
+        args:
+          - name: src
+            type: string
+            required: true
+            desc: Source path
+          - name: dst
+            type: string
+            required: true
+            desc: Destination path
+        return:
+          type: "null"
+          desc: Returns null on success
+
+      - name: Copy
+        desc: Copy a file or directory to a new location
+        args:
+          - name: src
+            type: string
+            required: true
+            desc: Source path
+          - name: dst
+            type: string
+            required: true
+            desc: Destination path
+        return:
+          type: "null"
+          desc: Returns null on success
+
+      - name: MoveAppend
+        desc: Move a file's content by appending it to the destination file
+        args:
+          - name: src
+            type: string
+            required: true
+            desc: Source file path
+          - name: dst
+            type: string
+            required: true
+            desc: Destination file path to append to
+        return:
+          type: "null"
+          desc: Returns null on success
+
+      - name: MoveInsert
+        desc: Move a file's content by inserting it at a byte offset in the destination file
+        args:
+          - name: src
+            type: string
+            required: true
+            desc: Source file path
+          - name: dst
+            type: string
+            required: true
+            desc: Destination file path
+          - name: offset
+            type: number
+            required: true
+            desc: Byte offset in the destination file
+        return:
+          type: "null"
+          desc: Returns null on success
+
+      - name: Abs
+        desc: Return the absolute path for a relative path within the file system
+        args:
+          - name: path
+            type: string
+            required: true
+            desc: Relative path
+        return:
+          type: string
+          desc: Absolute file system path
+
+      - name: Zip
+        desc: Compress a file or directory into a zip archive
+        args:
+          - name: src
+            type: string
+            required: true
+            desc: Source file or directory path to compress
+          - name: dst
+            type: string
+            required: true
+            desc: Destination zip file path
+        return:
+          type: "null"
+          desc: Returns null on success
+
+      - name: Unzip
+        desc: Extract a zip archive to a directory
+        args:
+          - name: src
+            type: string
+            required: true
+            desc: Source zip file path
+          - name: dst
+            type: string
+            required: true
+            desc: Destination directory path
+        return:
+          type: array
+          desc: Array of extracted file path strings
+
+      - name: Glob
+        desc: Find files matching a glob pattern
+        args:
+          - name: pattern
+            type: string
+            required: true
+            desc: "Glob pattern (e.g. \"/data/*.txt\")"
+        return:
+          type: array
+          desc: Array of matching file path strings

--- a/runtime/v8/objects/http/doc.go
+++ b/runtime/v8/objects/http/doc.go
@@ -1,0 +1,12 @@
+package http
+
+import (
+	_ "embed"
+
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/runtime/v8/objects/http/doc.yml
+++ b/runtime/v8/objects/http/doc.yml
@@ -1,0 +1,182 @@
+group: objects
+type: js_object
+entries:
+  - name: http
+    desc: Global HTTP client object for making HTTP requests from JavaScript
+    methods:
+      - name: Get
+        desc: Send an HTTP GET request
+        args:
+          - name: url
+            type: string
+            required: true
+            desc: Request URL
+          - name: params
+            type: any
+            required: false
+            desc: "Query parameters: object, array of key=value strings, or query string"
+          - name: headers
+            type: any
+            required: false
+            desc: "Request headers: object or array of key-value objects"
+        return:
+          type: object
+          desc: "Response object with status, data, headers, code, and message"
+
+      - name: Post
+        desc: Send an HTTP POST request with optional file uploads
+        args:
+          - name: url
+            type: string
+            required: true
+            desc: Request URL
+          - name: payload
+            type: any
+            required: false
+            desc: "Request body: object, array, string, or file path"
+          - name: files
+            type: object
+            required: false
+            desc: "Files to upload: map of field name to file path"
+          - name: params
+            type: any
+            required: false
+            desc: "Query parameters: object, array of key=value strings, or query string"
+          - name: headers
+            type: any
+            required: false
+            desc: "Request headers: object or array of key-value objects"
+        return:
+          type: object
+          desc: "Response object with status, data, headers, code, and message"
+
+      - name: Put
+        desc: Send an HTTP PUT request
+        args:
+          - name: url
+            type: string
+            required: true
+            desc: Request URL
+          - name: payload
+            type: any
+            required: false
+            desc: "Request body: object, array, string, or file path"
+          - name: params
+            type: any
+            required: false
+            desc: "Query parameters: object, array of key=value strings, or query string"
+          - name: headers
+            type: any
+            required: false
+            desc: "Request headers: object or array of key-value objects"
+        return:
+          type: object
+          desc: "Response object with status, data, headers, code, and message"
+
+      - name: Patch
+        desc: Send an HTTP PATCH request
+        args:
+          - name: url
+            type: string
+            required: true
+            desc: Request URL
+          - name: payload
+            type: any
+            required: false
+            desc: "Request body: object, array, string, or file path"
+          - name: params
+            type: any
+            required: false
+            desc: "Query parameters: object, array of key=value strings, or query string"
+          - name: headers
+            type: any
+            required: false
+            desc: "Request headers: object or array of key-value objects"
+        return:
+          type: object
+          desc: "Response object with status, data, headers, code, and message"
+
+      - name: Delete
+        desc: Send an HTTP DELETE request
+        args:
+          - name: url
+            type: string
+            required: true
+            desc: Request URL
+          - name: payload
+            type: any
+            required: false
+            desc: "Request body: object, array, string, or file path"
+          - name: params
+            type: any
+            required: false
+            desc: "Query parameters: object, array of key=value strings, or query string"
+          - name: headers
+            type: any
+            required: false
+            desc: "Request headers: object or array of key-value objects"
+        return:
+          type: object
+          desc: "Response object with status, data, headers, code, and message"
+
+      - name: Send
+        desc: Send an HTTP request with a specified method, supports file uploads for POST
+        args:
+          - name: method
+            type: string
+            required: true
+            desc: "HTTP method: GET, POST, PUT, HEAD, PATCH, DELETE, etc."
+          - name: url
+            type: string
+            required: true
+            desc: Request URL
+          - name: payload
+            type: any
+            required: false
+            desc: "Request body: object, array, string, or file path"
+          - name: params
+            type: any
+            required: false
+            desc: "Query parameters: object, array of key=value strings, or query string"
+          - name: headers
+            type: any
+            required: false
+            desc: "Request headers: object or array of key-value objects"
+          - name: files
+            type: array
+            required: false
+            desc: "Files to upload (POST only): array of objects with name, path, and base64-encoded data fields"
+        return:
+          type: object
+          desc: "Response object with status, data, headers, code, and message"
+
+      - name: Stream
+        desc: Send a streaming HTTP request and handle chunked responses via a callback function
+        args:
+          - name: method
+            type: string
+            required: true
+            desc: "HTTP method: GET, POST, PUT, PATCH, DELETE, etc."
+          - name: url
+            type: string
+            required: true
+            desc: Request URL
+          - name: callback
+            type: function
+            required: true
+            desc: "Callback function receiving each data chunk as a string; return 1 to continue, 0 to complete, -1 to abort"
+          - name: payload
+            type: any
+            required: false
+            desc: "Request body: object, array, string, or file path"
+          - name: params
+            type: any
+            required: false
+            desc: "Query parameters: object, array of key=value strings, or query string"
+          - name: headers
+            type: any
+            required: false
+            desc: "Request headers: object or array of key-value objects"
+        return:
+          type: object
+          desc: "Response object with status, data, headers, code, and message"

--- a/runtime/v8/objects/job/doc.go
+++ b/runtime/v8/objects/job/doc.go
@@ -1,0 +1,11 @@
+package job
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/runtime/v8/objects/job/doc.yml
+++ b/runtime/v8/objects/job/doc.yml
@@ -1,0 +1,39 @@
+group: objects
+type: js_class
+entries:
+  - name: Job
+    desc: Execute a process as a background job, allowing polling and cancellation
+    args:
+      - name: process
+        type: string
+        required: true
+        desc: Process name to execute in the background
+      - name: args
+        type: any
+        required: false
+        desc: Arguments to pass to the process (variadic)
+    methods:
+      - name: Pending
+        desc: Block execution while the job is running, calling a callback function repeatedly until the job completes or the callback returns false
+        args:
+          - name: callback
+            type: function
+            required: true
+            desc: "Callback function invoked while the job is running; return false to stop waiting"
+        return:
+          type: undefined
+          desc: Returns undefined
+
+      - name: Data
+        desc: Retrieve the result data of the completed job and remove it from the job registry
+        args: []
+        return:
+          type: any
+          desc: The result data from the process execution
+
+      - name: Cancel
+        desc: Cancel the running job and remove it from the job registry
+        args: []
+        return:
+          type: undefined
+          desc: Returns undefined

--- a/runtime/v8/objects/log/doc.go
+++ b/runtime/v8/objects/log/doc.go
@@ -1,0 +1,12 @@
+package log
+
+import (
+	_ "embed"
+
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/runtime/v8/objects/log/doc.yml
+++ b/runtime/v8/objects/log/doc.yml
@@ -1,0 +1,103 @@
+group: objects
+type: js_object
+entries:
+  - name: log
+    desc: Global logging object for writing structured log messages at various severity levels
+    methods:
+      - name: Trace
+        desc: Write a trace-level log message with optional format arguments
+        args:
+          - name: message
+            type: string
+            required: true
+            desc: Log message, supports printf-style format verbs
+          - name: args
+            type: any
+            required: false
+            desc: Variable arguments for format string substitution
+        return:
+          type: null
+
+      - name: Debug
+        desc: Write a debug-level log message with optional format arguments
+        args:
+          - name: message
+            type: string
+            required: true
+            desc: Log message, supports printf-style format verbs
+          - name: args
+            type: any
+            required: false
+            desc: Variable arguments for format string substitution
+        return:
+          type: null
+
+      - name: Info
+        desc: Write an info-level log message with optional format arguments
+        args:
+          - name: message
+            type: string
+            required: true
+            desc: Log message, supports printf-style format verbs
+          - name: args
+            type: any
+            required: false
+            desc: Variable arguments for format string substitution
+        return:
+          type: null
+
+      - name: Warn
+        desc: Write a warning-level log message with optional format arguments
+        args:
+          - name: message
+            type: string
+            required: true
+            desc: Log message, supports printf-style format verbs
+          - name: args
+            type: any
+            required: false
+            desc: Variable arguments for format string substitution
+        return:
+          type: null
+
+      - name: Error
+        desc: Write an error-level log message with optional format arguments
+        args:
+          - name: message
+            type: string
+            required: true
+            desc: Log message, supports printf-style format verbs
+          - name: args
+            type: any
+            required: false
+            desc: Variable arguments for format string substitution
+        return:
+          type: null
+
+      - name: Fatal
+        desc: Write a fatal-level log message with optional format arguments, then terminate the process
+        args:
+          - name: message
+            type: string
+            required: true
+            desc: Log message, supports printf-style format verbs
+          - name: args
+            type: any
+            required: false
+            desc: Variable arguments for format string substitution
+        return:
+          type: null
+
+      - name: Panic
+        desc: Write a panic-level log message with optional format arguments, then panic
+        args:
+          - name: message
+            type: string
+            required: true
+            desc: Log message, supports printf-style format verbs
+          - name: args
+            type: any
+            required: false
+            desc: Variable arguments for format string substitution
+        return:
+          type: null

--- a/runtime/v8/objects/plan/doc.go
+++ b/runtime/v8/objects/plan/doc.go
@@ -1,0 +1,11 @@
+package plan
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/runtime/v8/objects/plan/doc.yml
+++ b/runtime/v8/objects/plan/doc.yml
@@ -1,0 +1,150 @@
+group: objects
+type: js_class
+entries:
+  - name: Plan
+    desc: Execution plan for orchestrating concurrent tasks with a shared data space and event subscriptions
+    args:
+      - name: id
+        type: string
+        required: true
+        desc: Unique plan identifier
+    methods:
+      - name: Add
+        desc: Add a task to the plan with an execution order and a process or function
+        args:
+          - name: taskId
+            type: string
+            required: true
+            desc: Unique task identifier
+          - name: order
+            type: number
+            required: true
+            desc: Execution order (tasks with the same order run concurrently)
+          - name: handler
+            type: union
+            required: true
+            desc: "Process name string or callback function to execute"
+          - name: args
+            type: any
+            required: false
+            desc: Additional arguments passed to the handler (variadic)
+        return:
+          type: object
+          desc: Returns the Plan instance for chaining
+
+      - name: Run
+        desc: Start executing all tasks in the plan according to their order
+        args: []
+        return:
+          type: object
+          desc: Returns the Plan instance for chaining
+
+      - name: Status
+        desc: Get the status of the plan and all its tasks
+        args: []
+        return:
+          type: object
+          desc: "Object with plan (string) and tasks (map of taskId to status string: created, running, paused, completed, failed, destroyed, unknown)"
+
+      - name: Release
+        desc: Release the plan and free all associated resources
+        args: []
+        return:
+          type: "null"
+          desc: Returns null
+
+      - name: Results
+        desc: Get the result data from all completed tasks
+        args: []
+        return:
+          type: object
+          desc: Map of taskId to result value
+
+      - name: TaskStatus
+        desc: Get the status of a specific task
+        args:
+          - name: taskId
+            type: string
+            required: true
+            desc: Task identifier
+        return:
+          type: string
+          desc: "Task status: created, running, paused, completed, failed, destroyed, or unknown"
+
+      - name: TaskData
+        desc: Get or set the custom data of a specific task
+        args:
+          - name: taskId
+            type: string
+            required: true
+            desc: Task identifier
+          - name: data
+            type: any
+            required: false
+            desc: If provided, sets the task data; if omitted, returns the current task data
+        return:
+          type: any
+          desc: The task data (when getting) or null (when setting)
+
+      - name: Subscribe
+        desc: Subscribe to changes on a key in the shared space
+        args:
+          - name: key
+            type: string
+            required: true
+            desc: Key pattern to subscribe to
+          - name: handler
+            type: union
+            required: true
+            desc: Process name string or callback function invoked when the key changes
+          - name: args
+            type: any
+            required: false
+            desc: Additional arguments passed to the handler (variadic)
+        return:
+          type: "null"
+          desc: Returns null
+
+      - name: Set
+        desc: Set a value in the plan's shared data space
+        args:
+          - name: key
+            type: string
+            required: true
+            desc: Key name (reserved keys like TaskCompleted, TaskError, TaskStarted, Released are not allowed)
+          - name: value
+            type: any
+            required: true
+            desc: Value to store
+        return:
+          type: "null"
+          desc: Returns null
+
+      - name: Get
+        desc: Get a value from the plan's shared data space
+        args:
+          - name: key
+            type: string
+            required: true
+            desc: Key name
+        return:
+          type: any
+          desc: The stored value, or null if the key is not found
+
+      - name: Del
+        desc: Delete a value from the plan's shared data space
+        args:
+          - name: key
+            type: string
+            required: true
+            desc: Key name to delete
+        return:
+          type: "null"
+          desc: Returns null
+
+      - name: Clear
+        desc: Clear all values from the plan's shared data space
+        args: []
+        return:
+          type: "null"
+          desc: Returns null

--- a/runtime/v8/objects/query/doc.go
+++ b/runtime/v8/objects/query/doc.go
@@ -1,0 +1,11 @@
+package query
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/runtime/v8/objects/query/doc.yml
+++ b/runtime/v8/objects/query/doc.yml
@@ -1,0 +1,87 @@
+group: objects
+type: js_class
+entries:
+  - name: Query
+    desc: Database query builder using QueryDSL for executing queries against configured engines
+    args:
+      - name: engine
+        type: string
+        required: false
+        desc: "Query engine name (default: \"default\")"
+    methods:
+      - name: Get
+        desc: Execute a query and return all matching records
+        args:
+          - name: dsl
+            type: object
+            required: true
+            desc: "QueryDSL object (e.g. {select: [\"id\"], from: \"user\", limit: 10})"
+        return:
+          type: any
+          desc: Query result data (typically an array of records)
+
+      - name: First
+        desc: Execute a query and return only the first matching record
+        args:
+          - name: dsl
+            type: object
+            required: true
+            desc: "QueryDSL object (e.g. {select: [\"id\"], from: \"user\"})"
+        return:
+          type: any
+          desc: The first matching record or null
+
+      - name: Paginate
+        desc: Execute a query with pagination and return paginated results
+        args:
+          - name: dsl
+            type: object
+            required: true
+            desc: "QueryDSL object with pagination params (e.g. {select: [\"id\"], from: \"user\", pagesize: 20, page: 1})"
+        return:
+          type: any
+          desc: Paginated result object with data, total, page, etc.
+
+      - name: Run
+        desc: Execute a raw query statement
+        args:
+          - name: dsl
+            type: object
+            required: true
+            desc: "QueryDSL object with stmt field (e.g. {stmt: \"show version\"})"
+        return:
+          type: any
+          desc: Query execution result
+
+      - name: Lint
+        desc: Validate a QueryDSL JSON string and return parsing diagnostics
+        args:
+          - name: source
+            type: string
+            required: true
+            desc: QueryDSL as a JSON string
+        return:
+          type: object
+          desc: "Object with valid (bool), diagnostics (array of diagnostic objects), and dsl (parsed QueryDSL if valid)"
+
+      - name: Schema
+        desc: Get the JSON Schema definition for QueryDSL
+        args:
+          - name: format
+            type: string
+            required: false
+            desc: "Pass \"json\" to return as a JSON string; omit to return as an object"
+        return:
+          type: any
+          desc: QueryDSL JSON Schema as an object or JSON string
+
+      - name: Validate
+        desc: Validate a QueryDSL object against the JSON Schema
+        args:
+          - name: data
+            type: any
+            required: true
+            desc: QueryDSL object to validate
+        return:
+          type: object
+          desc: "Object with valid (bool) and error (string, present when invalid)"

--- a/runtime/v8/objects/store/doc.go
+++ b/runtime/v8/objects/store/doc.go
@@ -1,0 +1,11 @@
+package store
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/runtime/v8/objects/store/doc.yml
+++ b/runtime/v8/objects/store/doc.yml
@@ -1,0 +1,282 @@
+group: objects
+type: js_class
+entries:
+  - name: Store
+    desc: Key-value store with LRU cache, supporting basic CRUD, TTL, and list/array operations
+    args:
+      - name: name
+        type: string
+        required: true
+        desc: Name of the store pool to use
+    methods:
+      - name: Set
+        desc: Set a key-value pair with optional TTL
+        args:
+          - name: key
+            type: string
+            required: true
+            desc: Cache key
+          - name: value
+            type: any
+            required: true
+            desc: Value to store
+          - name: ttl
+            type: number
+            required: false
+            desc: "Time to live in seconds (default: 0, no expiry)"
+        return:
+          type: void
+          desc: Returns nothing
+
+      - name: Get
+        desc: Retrieve a value by key
+        args:
+          - name: key
+            type: string
+            required: true
+            desc: Cache key
+        return:
+          type: any
+          desc: The stored value, or undefined if not found
+
+      - name: GetSet
+        desc: Get a value by key; if not found, call the callback to compute and store it
+        args:
+          - name: key
+            type: string
+            required: true
+            desc: Cache key
+          - name: callback
+            type: function
+            required: true
+            desc: "Function(key) called to compute the value when the key is missing"
+          - name: ttl
+            type: number
+            required: false
+            desc: "Time to live in seconds (default: 0, no expiry)"
+        return:
+          type: any
+          desc: The existing or newly computed value
+
+      - name: GetDel
+        desc: Retrieve a value by key and delete it from the store
+        args:
+          - name: key
+            type: string
+            required: true
+            desc: Cache key
+        return:
+          type: any
+          desc: The stored value, or undefined if not found
+
+      - name: Has
+        desc: Check if a key exists in the store
+        args:
+          - name: key
+            type: string
+            required: true
+            desc: Cache key
+        return:
+          type: bool
+          desc: True if the key exists
+
+      - name: Del
+        desc: Delete a key from the store
+        args:
+          - name: key
+            type: string
+            required: true
+            desc: Cache key to delete
+        return:
+          type: undefined
+          desc: Returns undefined
+
+      - name: Keys
+        desc: Get all keys in the store
+        args: []
+        return:
+          type: array
+          desc: Array of key strings
+
+      - name: Len
+        desc: Get the number of entries in the store
+        args: []
+        return:
+          type: number
+          desc: Number of stored entries
+
+      - name: Clear
+        desc: Remove all entries from the store
+        args: []
+        return:
+          type: undefined
+          desc: Returns undefined
+
+      - name: Push
+        desc: Push one or more values to the end of an array stored at key
+        args:
+          - name: key
+            type: string
+            required: true
+            desc: Cache key for the array
+          - name: values
+            type: any
+            required: true
+            desc: Values to push (variadic)
+        return:
+          type: undefined
+          desc: Returns undefined
+
+      - name: Pop
+        desc: Remove and return the element at the given position from an array
+        args:
+          - name: key
+            type: string
+            required: true
+            desc: Cache key for the array
+          - name: position
+            type: number
+            required: true
+            desc: Index position to pop from
+        return:
+          type: any
+          desc: The removed element
+
+      - name: Pull
+        desc: Remove a specific value from an array stored at key
+        args:
+          - name: key
+            type: string
+            required: true
+            desc: Cache key for the array
+          - name: value
+            type: any
+            required: true
+            desc: Value to remove
+        return:
+          type: undefined
+          desc: Returns undefined
+
+      - name: PullAll
+        desc: Remove multiple values from an array stored at key
+        args:
+          - name: key
+            type: string
+            required: true
+            desc: Cache key for the array
+          - name: values
+            type: any
+            required: true
+            desc: Values to remove (variadic)
+        return:
+          type: undefined
+          desc: Returns undefined
+
+      - name: AddToSet
+        desc: Add values to an array stored at key, only if they are not already present (set behavior)
+        args:
+          - name: key
+            type: string
+            required: true
+            desc: Cache key for the set
+          - name: values
+            type: any
+            required: true
+            desc: Values to add (variadic)
+        return:
+          type: undefined
+          desc: Returns undefined
+
+      - name: ArrayLen
+        desc: Get the length of an array stored at key
+        args:
+          - name: key
+            type: string
+            required: true
+            desc: Cache key for the array
+        return:
+          type: number
+          desc: Length of the array
+
+      - name: ArrayGet
+        desc: Get the element at a specific index from an array stored at key
+        args:
+          - name: key
+            type: string
+            required: true
+            desc: Cache key for the array
+          - name: index
+            type: number
+            required: true
+            desc: Array index
+        return:
+          type: any
+          desc: The element at the given index
+
+      - name: ArraySet
+        desc: Set the element at a specific index in an array stored at key
+        args:
+          - name: key
+            type: string
+            required: true
+            desc: Cache key for the array
+          - name: index
+            type: number
+            required: true
+            desc: Array index
+          - name: value
+            type: any
+            required: true
+            desc: Value to set
+        return:
+          type: undefined
+          desc: Returns undefined
+
+      - name: ArraySlice
+        desc: Get a slice of elements from an array stored at key
+        args:
+          - name: key
+            type: string
+            required: true
+            desc: Cache key for the array
+          - name: skip
+            type: number
+            required: true
+            desc: Number of elements to skip
+          - name: limit
+            type: number
+            required: true
+            desc: Maximum number of elements to return
+        return:
+          type: array
+          desc: Array of sliced elements
+
+      - name: ArrayPage
+        desc: Get a page of elements from an array stored at key
+        args:
+          - name: key
+            type: string
+            required: true
+            desc: Cache key for the array
+          - name: page
+            type: number
+            required: true
+            desc: Page number (1-based)
+          - name: pageSize
+            type: number
+            required: true
+            desc: Number of elements per page
+        return:
+          type: array
+          desc: Array of elements for the requested page
+
+      - name: ArrayAll
+        desc: Get all elements from an array stored at key
+        args:
+          - name: key
+            type: string
+            required: true
+            desc: Cache key for the array
+        return:
+          type: array
+          desc: All elements in the array

--- a/runtime/v8/objects/time/doc.go
+++ b/runtime/v8/objects/time/doc.go
@@ -1,0 +1,12 @@
+package time
+
+import (
+	_ "embed"
+
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/runtime/v8/objects/time/doc.yml
+++ b/runtime/v8/objects/time/doc.yml
@@ -1,0 +1,33 @@
+group: objects
+type: js_object
+entries:
+  - name: time
+    desc: Global time utility object for sleeping and scheduling delayed process execution
+    methods:
+      - name: Sleep
+        desc: Block execution for the specified number of milliseconds
+        args:
+          - name: ms
+            type: number
+            required: true
+            desc: Duration to sleep in milliseconds
+        return:
+          type: null
+
+      - name: After
+        desc: Execute a named process asynchronously after a delay in milliseconds
+        args:
+          - name: ms
+            type: number
+            required: true
+            desc: Delay before execution in milliseconds
+          - name: process
+            type: string
+            required: true
+            desc: Name of the process to execute after the delay
+          - name: args
+            type: any
+            required: false
+            desc: Variable arguments passed to the process
+        return:
+          type: null

--- a/runtime/v8/objects/websocket/doc.go
+++ b/runtime/v8/objects/websocket/doc.go
@@ -1,0 +1,11 @@
+package websocket
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/runtime/v8/objects/websocket/doc.yml
+++ b/runtime/v8/objects/websocket/doc.yml
@@ -1,0 +1,25 @@
+group: objects
+type: js_class
+entries:
+  - name: WebSocket
+    desc: WebSocket client for sending messages to a WebSocket server
+    args:
+      - name: url
+        type: string
+        required: true
+        desc: WebSocket server URL (e.g. "ws://127.0.0.1:5056/websocket/test")
+      - name: protocols
+        type: string
+        required: false
+        desc: Sub-protocol strings (variadic, each additional argument is a protocol)
+    methods:
+      - name: push
+        desc: Connect to the WebSocket server and send a text message
+        args:
+          - name: message
+            type: string
+            required: true
+            desc: Text message to send
+        return:
+          type: undefined
+          desc: Returns undefined on success

--- a/schedule/doc.go
+++ b/schedule/doc.go
@@ -1,0 +1,11 @@
+package schedule
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/schedule/doc.yml
+++ b/schedule/doc.yml
@@ -1,0 +1,16 @@
+group: schedules
+type: process
+entries:
+  - name: start
+    desc: Start a loaded schedule by name (uses process.ID as the schedule name)
+    args: []
+    return:
+      type: object
+      desc: "Object with enabled status, e.g. {\"enabled\": true}"
+
+  - name: stop
+    desc: Stop a running schedule by name (uses process.ID as the schedule name)
+    args: []
+    return:
+      type: object
+      desc: "Object with enabled status, e.g. {\"enabled\": false}"

--- a/schema/doc.go
+++ b/schema/doc.go
@@ -1,0 +1,11 @@
+package schema
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/schema/doc.yml
+++ b/schema/doc.yml
@@ -1,0 +1,203 @@
+group: schemas
+type: process
+entries:
+  - name: create
+    desc: Create a new database schema
+    args:
+      - name: name
+        type: string
+        required: true
+        desc: Name of the schema to create
+    return:
+      type: "null"
+      desc: No return value
+
+  - name: drop
+    desc: Drop an existing database schema
+    args:
+      - name: name
+        type: string
+        required: true
+        desc: Name of the schema to drop
+    return:
+      type: "null"
+      desc: No return value
+
+  - name: tables
+    desc: Get the list of tables in the schema
+    args:
+      - name: prefix
+        type: string
+        required: false
+        desc: Optional table name prefix to filter by
+    return:
+      type: array
+      desc: Array of table names
+
+  - name: tableexists
+    desc: Check if a table exists in the schema
+    args:
+      - name: tableName
+        type: string
+        required: true
+        desc: Name of the table to check
+    return:
+      type: bool
+      desc: True if the table exists, false otherwise
+
+  - name: tableget
+    desc: Get the blueprint of a table
+    args:
+      - name: tableName
+        type: string
+        required: true
+        desc: Name of the table
+    return:
+      type: object
+      desc: Table blueprint object describing columns, indexes, and options
+
+  - name: tablecreate
+    desc: Create a new table with the given blueprint
+    args:
+      - name: tableName
+        type: string
+        required: true
+        desc: Name of the table to create
+      - name: blueprint
+        type: object
+        required: true
+        desc: Table blueprint defining columns, indexes, and options
+    return:
+      type: "null"
+      desc: No return value
+
+  - name: tabledrop
+    desc: Drop an existing table
+    args:
+      - name: tableName
+        type: string
+        required: true
+        desc: Name of the table to drop
+    return:
+      type: "null"
+      desc: No return value
+
+  - name: tablerename
+    desc: Rename an existing table
+    args:
+      - name: tableName
+        type: string
+        required: true
+        desc: Current name of the table
+      - name: newTableName
+        type: string
+        required: true
+        desc: New name for the table
+    return:
+      type: "null"
+      desc: No return value
+
+  - name: tablediff
+    desc: Compare two table blueprints and return the differences
+    args:
+      - name: blueprint
+        type: object
+        required: true
+        desc: First table blueprint
+      - name: anotherBlueprint
+        type: object
+        required: true
+        desc: Second table blueprint to compare against
+    return:
+      type: object
+      desc: Object describing the differences between the two blueprints
+
+  - name: tablesave
+    desc: Save a table; creates the table if it does not exist, otherwise updates it
+    args:
+      - name: tableName
+        type: string
+        required: true
+        desc: Name of the table to save
+      - name: blueprint
+        type: object
+        required: true
+        desc: Table blueprint defining columns, indexes, and options
+    return:
+      type: "null"
+      desc: No return value
+
+  - name: columnadd
+    desc: Add a column to the given table
+    args:
+      - name: tableName
+        type: string
+        required: true
+        desc: Name of the table
+      - name: column
+        type: object
+        required: true
+        desc: Column definition object
+    return:
+      type: "null"
+      desc: No return value
+
+  - name: columnalt
+    desc: Alter a column in the given table; adds the column if it does not exist
+    args:
+      - name: tableName
+        type: string
+        required: true
+        desc: Name of the table
+      - name: column
+        type: object
+        required: true
+        desc: Column definition object
+    return:
+      type: "null"
+      desc: No return value
+
+  - name: columndel
+    desc: Delete a column from the given table
+    args:
+      - name: tableName
+        type: string
+        required: true
+        desc: Name of the table
+      - name: columnName
+        type: string
+        required: true
+        desc: Name of the column to delete
+    return:
+      type: "null"
+      desc: No return value
+
+  - name: indexadd
+    desc: Add an index to the given table
+    args:
+      - name: tableName
+        type: string
+        required: true
+        desc: Name of the table
+      - name: index
+        type: object
+        required: true
+        desc: Index definition object
+    return:
+      type: "null"
+      desc: No return value
+
+  - name: indexdel
+    desc: Delete an index from the given table
+    args:
+      - name: tableName
+        type: string
+        required: true
+        desc: Name of the table
+      - name: indexName
+        type: string
+        required: true
+        desc: Name of the index to delete
+    return:
+      type: "null"
+      desc: No return value

--- a/session/doc.go
+++ b/session/doc.go
@@ -1,0 +1,11 @@
+package session
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/session/doc.yml
+++ b/session/doc.yml
@@ -1,0 +1,122 @@
+group: session
+type: process
+entries:
+  - name: id
+    desc: Get the current session ID
+    args: []
+    return:
+      type: string
+      desc: The current session ID
+
+  - name: get
+    desc: Get a value from the session by key
+    args:
+      - name: key
+        type: string
+        required: true
+        desc: Session key to retrieve
+      - name: sid
+        type: string
+        required: false
+        desc: Optional session ID to read from a different session
+    return:
+      type: any
+      desc: The value stored at the given key
+
+  - name: set
+    desc: Set a value in the session
+    args:
+      - name: key
+        type: string
+        required: true
+        desc: Session key to set
+      - name: value
+        type: any
+        required: true
+        desc: Value to store
+      - name: ttl
+        type: number
+        required: false
+        desc: Time-to-live in seconds
+      - name: sid
+        type: string
+        required: false
+        desc: Optional session ID to write to a different session (requires ttl to be set)
+    return:
+      type: "null"
+      desc: No return value
+
+  - name: del
+    desc: Delete a value from the session by key
+    args:
+      - name: key
+        type: string
+        required: true
+        desc: Session key to delete
+      - name: sid
+        type: string
+        required: false
+        desc: Optional session ID to delete from a different session
+    return:
+      type: "null"
+      desc: No return value
+
+  - name: dump
+    desc: Dump all key-value pairs in the session
+    args:
+      - name: sid
+        type: string
+        required: false
+        desc: Optional session ID to dump a different session
+    return:
+      type: object
+      desc: Map of all session key-value pairs
+
+  - name: getmany
+    desc: Get multiple values from the session by keys
+    args:
+      - name: keys
+        type: array
+        required: true
+        desc: Array of session keys to retrieve
+      - name: sid
+        type: string
+        required: false
+        desc: Optional session ID to read from a different session
+    return:
+      type: object
+      desc: Map of key to value for the requested keys
+
+  - name: setmany
+    desc: Set multiple key-value pairs in the session
+    args:
+      - name: values
+        type: object
+        required: true
+        desc: Map of key-value pairs to set
+      - name: ttl
+        type: number
+        required: false
+        desc: Time-to-live in seconds
+      - name: sid
+        type: string
+        required: false
+        desc: Optional session ID to write to a different session (requires ttl to be set)
+    return:
+      type: "null"
+      desc: No return value
+
+  - name: delmany
+    desc: Delete multiple values from the session by keys
+    args:
+      - name: keys
+        type: array
+        required: true
+        desc: Array of session keys to delete
+      - name: sid
+        type: string
+        required: false
+        desc: Optional session ID to delete from a different session
+    return:
+      type: "null"
+      desc: No return value

--- a/ssl/doc.go
+++ b/ssl/doc.go
@@ -1,0 +1,12 @@
+package ssl
+
+import (
+	_ "embed"
+
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/ssl/doc.yml
+++ b/ssl/doc.yml
@@ -1,0 +1,44 @@
+group: ssl
+type: process
+entries:
+  - name: ssl.sign
+    desc: Compute a cryptographic signature for the given data using an RSA private key
+    args:
+      - name: data
+        type: string
+        required: true
+        desc: The plain text data to sign
+      - name: certName
+        type: string
+        required: true
+        desc: The name of the loaded private key certificate
+      - name: algorithm
+        type: string
+        required: true
+        desc: "The hash algorithm (e.g. SHA256, SHA512, MD5)"
+    return:
+      type: string
+      desc: Base64-encoded RSA signature
+
+  - name: ssl.verify
+    desc: Verify that a signature is valid for the given data using an RSA public key or certificate
+    args:
+      - name: data
+        type: string
+        required: true
+        desc: The original plain text data
+      - name: sign
+        type: string
+        required: true
+        desc: The base64-encoded signature to verify
+      - name: certName
+        type: string
+        required: true
+        desc: The name of the loaded public key or certificate
+      - name: algorithm
+        type: string
+        required: true
+        desc: "The hash algorithm used when signing (e.g. SHA256, SHA512, MD5)"
+    return:
+      type: bool
+      desc: True if the signature is valid, throws on failure

--- a/store/doc.go
+++ b/store/doc.go
@@ -1,0 +1,11 @@
+package store
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/store/doc.yml
+++ b/store/doc.yml
@@ -1,0 +1,255 @@
+group: stores
+type: process
+entries:
+  - name: get
+    desc: Get a value by key from the store
+    args:
+      - name: key
+        type: string
+        required: true
+        desc: The key to retrieve
+    return:
+      type: any
+      desc: The stored value, or null if the key does not exist
+
+  - name: set
+    desc: Set a key-value pair in the store with optional TTL
+    args:
+      - name: key
+        type: string
+        required: true
+        desc: The key to set
+      - name: value
+        type: any
+        required: true
+        desc: The value to store
+      - name: ttl
+        type: number
+        required: false
+        desc: Time-to-live in seconds (default 0, no expiration)
+    return:
+      type: "null"
+      desc: Returns null on success
+
+  - name: has
+    desc: Check if a key exists in the store
+    args:
+      - name: key
+        type: string
+        required: true
+        desc: The key to check
+    return:
+      type: bool
+      desc: True if the key exists
+
+  - name: del
+    desc: Delete a key from the store
+    args:
+      - name: key
+        type: string
+        required: true
+        desc: The key to delete
+    return:
+      type: "null"
+      desc: Returns null on success
+
+  - name: getdel
+    desc: Get a value by key and delete it atomically
+    args:
+      - name: key
+        type: string
+        required: true
+        desc: The key to retrieve and delete
+    return:
+      type: any
+      desc: The stored value, or null if the key does not exist
+
+  - name: len
+    desc: Get the number of keys in the store
+    args: []
+    return:
+      type: number
+      desc: Number of keys in the store
+
+  - name: keys
+    desc: Get all keys in the store
+    args: []
+    return:
+      type: array
+      desc: Array of all keys in the store
+
+  - name: clear
+    desc: Remove all keys from the store
+    args: []
+    return:
+      type: "null"
+      desc: Returns null on success
+
+  - name: push
+    desc: Push one or more values to the end of an array stored at the given key
+    args:
+      - name: key
+        type: string
+        required: true
+        desc: The key of the array
+      - name: values
+        type: any
+        required: true
+        desc: One or more values to push (variadic)
+    return:
+      type: any
+      desc: "Null on success, error on failure"
+
+  - name: pop
+    desc: Remove and return an element from an array at the given position
+    args:
+      - name: key
+        type: string
+        required: true
+        desc: The key of the array
+      - name: position
+        type: number
+        required: true
+        desc: "Position to pop from (0 = first, -1 = last)"
+    return:
+      type: any
+      desc: The removed value, or null on error
+
+  - name: pull
+    desc: Remove the first occurrence of a value from an array
+    args:
+      - name: key
+        type: string
+        required: true
+        desc: The key of the array
+      - name: value
+        type: any
+        required: true
+        desc: The value to remove
+    return:
+      type: any
+      desc: "Null on success, error on failure"
+
+  - name: pullall
+    desc: Remove all occurrences of the given values from an array
+    args:
+      - name: key
+        type: string
+        required: true
+        desc: The key of the array
+      - name: values
+        type: any
+        required: true
+        desc: A value, array of values, or multiple values to remove
+    return:
+      type: any
+      desc: "Null on success, error on failure"
+
+  - name: addtoset
+    desc: Add one or more values to an array only if they do not already exist (set-like behavior)
+    args:
+      - name: key
+        type: string
+        required: true
+        desc: The key of the array
+      - name: values
+        type: any
+        required: true
+        desc: One or more values to add (variadic)
+    return:
+      type: any
+      desc: "Null on success, error on failure"
+
+  - name: arraylen
+    desc: Get the length of an array stored at the given key
+    args:
+      - name: key
+        type: string
+        required: true
+        desc: The key of the array
+    return:
+      type: number
+      desc: Length of the array
+
+  - name: arrayget
+    desc: Get an element from an array by index
+    args:
+      - name: key
+        type: string
+        required: true
+        desc: The key of the array
+      - name: index
+        type: number
+        required: true
+        desc: The array index
+    return:
+      type: any
+      desc: The value at the given index, or null on error
+
+  - name: arrayset
+    desc: Set an element in an array at a specific index
+    args:
+      - name: key
+        type: string
+        required: true
+        desc: The key of the array
+      - name: index
+        type: number
+        required: true
+        desc: The array index to set
+      - name: value
+        type: any
+        required: true
+        desc: The value to set
+    return:
+      type: any
+      desc: "Null on success, error on failure"
+
+  - name: arrayslice
+    desc: Get a slice of an array by skip and limit
+    args:
+      - name: key
+        type: string
+        required: true
+        desc: The key of the array
+      - name: skip
+        type: number
+        required: true
+        desc: Number of elements to skip
+      - name: limit
+        type: number
+        required: true
+        desc: Maximum number of elements to return
+    return:
+      type: array
+      desc: Array slice, or null on error
+
+  - name: arraypage
+    desc: Get a paginated slice of an array
+    args:
+      - name: key
+        type: string
+        required: true
+        desc: The key of the array
+      - name: page
+        type: number
+        required: true
+        desc: Page number (1-based)
+      - name: pageSize
+        type: number
+        required: true
+        desc: Number of elements per page
+    return:
+      type: array
+      desc: Paginated array slice, or null on error
+
+  - name: arrayall
+    desc: Get all elements of an array stored at the given key
+    args:
+      - name: key
+        type: string
+        required: true
+        desc: The key of the array
+    return:
+      type: array
+      desc: All elements in the array, or null on error

--- a/task/doc.go
+++ b/task/doc.go
@@ -1,0 +1,11 @@
+package task
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/task/doc.yml
+++ b/task/doc.yml
@@ -1,0 +1,47 @@
+group: tasks
+type: process
+entries:
+  - name: add
+    desc: Add a new job to the task queue for asynchronous execution
+    args:
+      - name: args
+        type: any
+        required: false
+        desc: Variable arguments to pass to the task handler
+    return:
+      type: number
+      desc: The job ID of the newly added task
+
+  - name: progress
+    desc: Update the progress of an existing task job
+    args:
+      - name: id
+        type: number
+        required: true
+        desc: The job ID
+      - name: current
+        type: number
+        required: true
+        desc: Current progress value
+      - name: total
+        type: number
+        required: true
+        desc: Total progress value
+      - name: message
+        type: string
+        required: true
+        desc: Progress status message
+    return:
+      type: "null"
+      desc: No return value
+
+  - name: get
+    desc: Get the status and details of a task job by ID
+    args:
+      - name: id
+        type: number
+        required: true
+        desc: The job ID
+    return:
+      type: object
+      desc: The job details including status, progress, and result

--- a/text/doc.go
+++ b/text/doc.go
@@ -1,0 +1,11 @@
+package text
+
+import (
+	_ "embed"
+	"github.com/yaoapp/gou/doc"
+)
+
+//go:embed doc.yml
+var docYAML []byte
+
+func init() { doc.LoadYAML(docYAML) }

--- a/text/doc.yml
+++ b/text/doc.yml
@@ -1,0 +1,72 @@
+group: text
+type: process
+entries:
+  - name: extract
+    desc: Extract all code blocks from text (typically LLM output), detecting markdown fences and direct JSON/HTML/code
+    args:
+      - name: text
+        type: string
+        required: true
+        desc: The text to extract code blocks from
+    return:
+      type: array
+      desc: Array of CodeBlock objects with type, content, and data fields
+
+  - name: extractfirst
+    desc: Extract and return only the first code block from text
+    args:
+      - name: text
+        type: string
+        required: true
+        desc: The text to extract from
+    return:
+      type: object
+      desc: The first CodeBlock object, or null if none found
+
+  - name: extractjson
+    desc: Extract the first JSON or YAML block and return the parsed data directly
+    args:
+      - name: text
+        type: string
+        required: true
+        desc: The text containing JSON or YAML
+    return:
+      type: any
+      desc: Parsed data from the first JSON/YAML block, or null if none found
+
+  - name: extractbytype
+    desc: Extract all code blocks of a specific type from text
+    args:
+      - name: text
+        type: string
+        required: true
+        desc: The text to extract from
+      - name: blockType
+        type: string
+        required: true
+        desc: The block type to filter by (e.g. "json", "html", "sql")
+    return:
+      type: array
+      desc: Array of matching CodeBlock objects
+
+  - name: markdowntohtml
+    desc: Convert Markdown text to HTML with GitHub Flavored Markdown support (tables, strikethrough, task lists, autolinks)
+    args:
+      - name: markdown
+        type: string
+        required: true
+        desc: The Markdown text to convert
+    return:
+      type: string
+      desc: The converted HTML content
+
+  - name: htmltomarkdown
+    desc: Convert HTML content to Markdown text
+    args:
+      - name: html
+        type: string
+        required: true
+        desc: The HTML content to convert
+    return:
+      type: string
+      desc: The converted Markdown text


### PR DESCRIPTION
Introduce gou/doc/ package providing a central registry for process and JS runtime documentation. Each package embeds its own doc.yml via go:embed.

- doc/types.go: Entry, TypeValue, Method, Endpoint structs
- doc/loader.go: YAML loading with process name normalisation
- doc/registry.go: thread-safe entry registry with callable-name resolution
- doc/query.go: List, Validate, Search, Groups, Stats queries
- doc/auto.go: AutoDiscover, CallableName for dynamic-ID groups
- doc/doc_test.go: comprehensive unit tests
- 42 process doc.yml + doc.go pairs across all packages
- 22 runtime (objects/functions) doc.yml + doc.go pairs
- 1 MCP jsapi doc.yml + doc.go pair

Made-with: Cursor