### PR TITLE
feat(connector): add ExtraBody parameter to OpenAI and Anthropic conn…

### DIFF
--- a/connector/anthropic/anthropic.go
+++ b/connector/anthropic/anthropic.go
@@ -44,6 +44,10 @@ type Options struct {
 	// Supported API protocols. Defaults to ["anthropic"] when empty.
 	// Dual-protocol gateways declare ["openai", "anthropic"].
 	Protocols []string `json:"protocols,omitempty"`
+
+	// Extra parameters forwarded verbatim into the API request body.
+	// Aligned with LiteLLM's extra_body convention.
+	ExtraBody map[string]interface{} `json:"extra_body,omitempty"`
 }
 
 // Capabilities is an alias for llm.Capabilities for backward compatibility.
@@ -127,6 +131,12 @@ func (c *Connector) Setting() map[string]interface{} {
 	}
 	if len(c.Options.Protocols) > 0 {
 		setting["protocols"] = c.Options.Protocols
+	}
+
+	for k, v := range c.Options.ExtraBody {
+		if _, exists := setting[k]; !exists {
+			setting[k] = v
+		}
 	}
 
 	return setting

--- a/connector/openai/openai.go
+++ b/connector/openai/openai.go
@@ -43,6 +43,11 @@ type Options struct {
 	// Supported API protocols. Defaults to ["openai"] when empty.
 	// Dual-protocol gateways (e.g. LiteLLM) declare ["openai", "anthropic"].
 	Protocols []string `json:"protocols,omitempty"`
+
+	// Extra parameters forwarded verbatim into the API request body.
+	// Aligned with LiteLLM's extra_body convention.
+	// Examples: reasoning, enable_thinking, thinkingConfig.
+	ExtraBody map[string]interface{} `json:"extra_body,omitempty"`
 }
 
 // Capabilities is an alias for llm.Capabilities for backward compatibility.
@@ -122,6 +127,12 @@ func (o *Connector) Setting() map[string]interface{} {
 	}
 	if len(o.Options.Protocols) > 0 {
 		setting["protocols"] = o.Options.Protocols
+	}
+
+	for k, v := range o.Options.ExtraBody {
+		if _, exists := setting[k]; !exists {
+			setting[k] = v
+		}
 	}
 
 	return setting

--- a/connector/params.go
+++ b/connector/params.go
@@ -15,6 +15,7 @@ var defaultParamsByType = map[string]map[string]*llm.ParamSpec{
 		"tools": nil, "tool_choice": nil,
 		"reasoning_effort": nil, "audio": nil, "thinking": nil,
 		"stream_options": nil,
+		"reasoning":      nil, "enable_thinking": nil, "thinkingConfig": nil,
 	},
 	"anthropic": {
 		"temperature": nil, "max_tokens": nil,


### PR DESCRIPTION
…ectors

- Introduced ExtraBody field in Options struct for both OpenAI and Anthropic connectors, allowing additional parameters to be forwarded directly into the API request body.
- Updated Setting method to include ExtraBody parameters in the connector settings, ensuring they are properly integrated into requests.
- Enhanced documentation comments to clarify the purpose and usage of the ExtraBody field.