### PR TITLE
feat(mediaprobe): enhance MP4 probing with additional atom support an…

### DIFF
--- a/mediaprobe/mp4.go
+++ b/mediaprobe/mp4.go
@@ -14,6 +14,9 @@ var mp4ContainerAtoms = map[string]bool{
 	"stbl": true,
 	"udta": true,
 	"edts": true,
+	"mvex": true,
+	"moof": true,
+	"traf": true,
 }
 
 type atomVisitor func(path string, r io.ReadSeeker, size int64) error
@@ -97,10 +100,14 @@ func probeMP4(r io.ReadSeeker) (*MediaInfo, error) {
 	}
 
 	var (
-		foundMoov bool
-		duration  float64
-		width     int
-		height    int
+		foundMoov        bool
+		duration         float64
+		width            int
+		height           int
+		mdhdTimescale    uint32
+		defaultSampleDur uint32 // from trex
+		currentFragDur   uint32 // per-fragment default from tfhd
+		fragDurationSum  uint64
 	)
 
 	visitor := func(path string, payload io.ReadSeeker, size int64) error {
@@ -126,6 +133,28 @@ func probeMP4(r io.ReadSeeker) (*MediaInfo, error) {
 					height = h
 				}
 			}
+		case "mdhd":
+			if ts, err := parseMP4MDHD(payload, size); err == nil && ts > 0 {
+				mdhdTimescale = ts
+			}
+		case "trex":
+			if defDur, err := parseMP4TREX(payload, size); err == nil {
+				defaultSampleDur = defDur
+			}
+		case "traf":
+			currentFragDur = 0
+		case "tfhd":
+			if defDur, err := parseMP4TFHD(payload, size); err == nil && defDur > 0 {
+				currentFragDur = defDur
+			}
+		case "trun":
+			defDur := currentFragDur
+			if defDur == 0 {
+				defDur = defaultSampleDur
+			}
+			if sum, err := parseMP4TRUN(payload, size, defDur); err == nil {
+				fragDurationSum += sum
+			}
 		}
 		return nil
 	}
@@ -136,6 +165,10 @@ func probeMP4(r io.ReadSeeker) (*MediaInfo, error) {
 
 	if !foundMoov {
 		return nil, fmt.Errorf("mediaprobe: mp4: %w", ErrInvalidFile)
+	}
+
+	if duration == 0 && fragDurationSum > 0 && mdhdTimescale > 0 {
+		duration = float64(fragDurationSum) / float64(mdhdTimescale)
 	}
 
 	return &MediaInfo{
@@ -237,4 +270,134 @@ func parseMP4TKHD(r io.ReadSeeker, size int64) (int, int, error) {
 	w := int(binary.BigEndian.Uint32(dims[0:4]) >> 16)
 	h := int(binary.BigEndian.Uint32(dims[4:8]) >> 16)
 	return w, h, nil
+}
+
+// parseMP4MDHD extracts timescale from Media Header Box.
+func parseMP4MDHD(r io.ReadSeeker, size int64) (uint32, error) {
+	if size < 4 {
+		return 0, fmt.Errorf("mediaprobe: mp4 mdhd: %w", ErrInvalidFile)
+	}
+	var vf [4]byte
+	if _, err := io.ReadFull(r, vf[:]); err != nil {
+		return 0, err
+	}
+	switch vf[0] {
+	case 0:
+		if size < 20 {
+			return 0, fmt.Errorf("mediaprobe: mp4 mdhd: %w", ErrInvalidFile)
+		}
+		var buf [12]byte
+		if _, err := io.ReadFull(r, buf[:]); err != nil {
+			return 0, err
+		}
+		return binary.BigEndian.Uint32(buf[8:12]), nil
+	case 1:
+		if size < 32 {
+			return 0, fmt.Errorf("mediaprobe: mp4 mdhd: %w", ErrInvalidFile)
+		}
+		var buf [20]byte
+		if _, err := io.ReadFull(r, buf[:]); err != nil {
+			return 0, err
+		}
+		return binary.BigEndian.Uint32(buf[16:20]), nil
+	}
+	return 0, fmt.Errorf("mediaprobe: mp4 mdhd: %w", ErrInvalidFile)
+}
+
+// parseMP4TREX extracts default_sample_duration from Track Extends Box.
+func parseMP4TREX(r io.ReadSeeker, size int64) (uint32, error) {
+	if size < 24 {
+		return 0, fmt.Errorf("mediaprobe: mp4 trex: %w", ErrInvalidFile)
+	}
+	var buf [24]byte
+	if _, err := io.ReadFull(r, buf[:]); err != nil {
+		return 0, err
+	}
+	// [0:4] version+flags, [4:8] trackID, [8:12] defSampleDescIdx,
+	// [12:16] defSampleDuration, [16:20] defSampleSize, [20:24] defSampleFlags
+	return binary.BigEndian.Uint32(buf[12:16]), nil
+}
+
+// parseMP4TFHD extracts default_sample_duration from Track Fragment Header.
+func parseMP4TFHD(r io.ReadSeeker, size int64) (uint32, error) {
+	if size < 8 {
+		return 0, nil
+	}
+	var buf [8]byte
+	if _, err := io.ReadFull(r, buf[:]); err != nil {
+		return 0, err
+	}
+	flags := uint32(buf[1])<<16 | uint32(buf[2])<<8 | uint32(buf[3])
+	offset := int64(8) // past version+flags + trackID
+
+	if flags&0x01 != 0 { // base-data-offset-present
+		offset += 8
+	}
+	if flags&0x02 != 0 { // sample-description-index-present
+		offset += 4
+	}
+	if flags&0x08 == 0 { // default-sample-duration NOT present
+		return 0, nil
+	}
+	toSkip := offset - 8
+	if toSkip > 0 {
+		if _, err := r.Seek(toSkip, io.SeekCurrent); err != nil {
+			return 0, err
+		}
+	}
+	var dur [4]byte
+	if _, err := io.ReadFull(r, dur[:]); err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint32(dur[:]), nil
+}
+
+// parseMP4TRUN sums sample durations from a Track Run Box.
+// defDur is used when individual sample durations are absent.
+func parseMP4TRUN(r io.ReadSeeker, size int64, defDur uint32) (uint64, error) {
+	if size < 8 {
+		return 0, fmt.Errorf("mediaprobe: mp4 trun: %w", ErrInvalidFile)
+	}
+	var hdr [8]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return 0, err
+	}
+	flags := uint32(hdr[1])<<16 | uint32(hdr[2])<<8 | uint32(hdr[3])
+	sampleCount := binary.BigEndian.Uint32(hdr[4:8])
+
+	// Skip optional header fields
+	if flags&0x001 != 0 { // data-offset-present
+		r.Seek(4, io.SeekCurrent)
+	}
+	if flags&0x004 != 0 { // first-sample-flags-present
+		r.Seek(4, io.SeekCurrent)
+	}
+
+	hasDuration := flags&0x100 != 0
+	hasSize := flags&0x200 != 0
+	hasFlags := flags&0x400 != 0
+	hasCTO := flags&0x800 != 0
+
+	if !hasDuration {
+		return uint64(sampleCount) * uint64(defDur), nil
+	}
+
+	var total uint64
+	for i := uint32(0); i < sampleCount; i++ {
+		var dur [4]byte
+		if _, err := io.ReadFull(r, dur[:]); err != nil {
+			return total, err
+		}
+		total += uint64(binary.BigEndian.Uint32(dur[:]))
+		if hasSize {
+			r.Seek(4, io.SeekCurrent)
+		}
+		if hasFlags {
+			r.Seek(4, io.SeekCurrent)
+		}
+		if hasCTO {
+			r.Seek(4, io.SeekCurrent)
+		}
+	}
+	return total, nil
 }

--- a/mediaprobe/probe.go
+++ b/mediaprobe/probe.go
@@ -52,6 +52,8 @@ func ProbeReader(r io.ReadSeeker, hint string) (*MediaInfo, error) {
 		return probeFLAC(r)
 	case "ogg":
 		return probeOGG(r)
+	case "webm":
+		return probeWebM(r)
 	case "jpeg", "jpg", "png", "gif", "webp", "bmp", "tiff":
 		return probeImage(r, format)
 	default:
@@ -79,6 +81,8 @@ func detectFormat(r io.ReadSeeker, hint string) string {
 		return "flac"
 	case bytes.Equal(buf[:4], []byte("OggS")):
 		return "ogg"
+	case bytes.Equal(buf[:4], []byte{0x1A, 0x45, 0xDF, 0xA3}):
+		return "webm"
 	case n >= 8 && bytes.Equal(buf[4:8], []byte("ftyp")):
 		return "mp4"
 	case buf[0] == 0xFF && (buf[1]&0xE0) == 0xE0:
@@ -105,7 +109,7 @@ func detectFormat(r io.ReadSeeker, hint string) string {
 func normalizeHint(hint string) string {
 	h := strings.ToLower(strings.TrimPrefix(hint, "."))
 	switch h {
-	case "wav", "mp3", "flac", "ogg", "opus":
+	case "wav", "mp3", "flac", "ogg", "opus", "webm":
 		return h
 	case "mp4", "m4a", "m4v", "mov":
 		return "mp4"
@@ -126,6 +130,8 @@ func normalizeHint(hint string) string {
 		return "flac"
 	case "audio/ogg", "audio/opus":
 		return "ogg"
+	case "audio/webm", "video/webm":
+		return "webm"
 	case "image/jpeg":
 		return "jpeg"
 	case "image/png":

--- a/mediaprobe/webm.go
+++ b/mediaprobe/webm.go
@@ -1,0 +1,237 @@
+package mediaprobe
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+)
+
+const (
+	ebmlHeaderID  = 0x1A45DFA3
+	ebmlSegment   = 0x18538067
+	ebmlInfo      = 0x1549A966
+	ebmlCluster   = 0x1F43B675
+	ebmlTSScale   = 0x2AD7B1
+	ebmlDuration  = 0x4489
+	ebmlTimestamp = 0xE7
+)
+
+// readVINT reads an EBML variable-size integer.
+// When raw is true the VINT_MARKER bit is kept (element IDs);
+// when false the marker is stripped (data sizes).
+func readVINT(r io.Reader, raw bool) (uint64, int, error) {
+	var b [1]byte
+	if _, err := io.ReadFull(r, b[:]); err != nil {
+		return 0, 0, err
+	}
+	first := b[0]
+	if first == 0 {
+		return 0, 0, fmt.Errorf("mediaprobe: webm: invalid VINT")
+	}
+
+	width := 1
+	for mask := byte(0x80); mask > 0 && first&mask == 0; mask >>= 1 {
+		width++
+	}
+
+	val := uint64(first)
+	if !raw {
+		val &^= uint64(1 << (8 - uint(width)))
+	}
+
+	if width > 1 {
+		extra := make([]byte, width-1)
+		if _, err := io.ReadFull(r, extra); err != nil {
+			return 0, 0, err
+		}
+		for _, eb := range extra {
+			val = val<<8 | uint64(eb)
+		}
+	}
+	return val, width, nil
+}
+
+func vintIsUnknown(val uint64, width int) bool {
+	return val == (1<<(7*uint(width)))-1
+}
+
+func ebmlReadUint(r io.Reader, n int) (uint64, error) {
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return 0, err
+	}
+	var v uint64
+	for _, b := range buf {
+		v = v<<8 | uint64(b)
+	}
+	return v, nil
+}
+
+func probeWebM(r io.ReadSeeker) (*MediaInfo, error) {
+	if _, err := r.Seek(0, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("mediaprobe: webm seek: %w", err)
+	}
+
+	id, _, err := readVINT(r, true)
+	if err != nil || id != ebmlHeaderID {
+		return nil, fmt.Errorf("mediaprobe: webm: %w", ErrInvalidFile)
+	}
+	hdrSize, _, err := readVINT(r, false)
+	if err != nil {
+		return nil, fmt.Errorf("mediaprobe: webm: %w", err)
+	}
+	if _, err := r.Seek(int64(hdrSize), io.SeekCurrent); err != nil {
+		return nil, fmt.Errorf("mediaprobe: webm: %w", err)
+	}
+
+	segID, _, err := readVINT(r, true)
+	if err != nil || segID != ebmlSegment {
+		return nil, fmt.Errorf("mediaprobe: webm: %w", ErrInvalidFile)
+	}
+	segSize, segW, err := readVINT(r, false)
+	if err != nil {
+		return nil, fmt.Errorf("mediaprobe: webm: %w", err)
+	}
+
+	segStart, _ := r.Seek(0, io.SeekCurrent)
+	segEnd := segStart + int64(segSize)
+	if vintIsUnknown(segSize, segW) {
+		end, err := r.Seek(0, io.SeekEnd)
+		if err != nil {
+			return nil, fmt.Errorf("mediaprobe: webm: %w", err)
+		}
+		segEnd = end
+		if _, err := r.Seek(segStart, io.SeekStart); err != nil {
+			return nil, fmt.Errorf("mediaprobe: webm: %w", err)
+		}
+	}
+
+	var (
+		tsScale       uint64 = 1000000 // default 1 ms
+		infoDuration  float64
+		hasDuration   bool
+		lastClusterTS int64 = -1
+	)
+
+	for {
+		pos, err := r.Seek(0, io.SeekCurrent)
+		if err != nil || pos >= segEnd {
+			break
+		}
+		elemID, _, err := readVINT(r, true)
+		if err != nil {
+			break
+		}
+		elemSize, elemW, err := readVINT(r, false)
+		if err != nil {
+			break
+		}
+		dataPos, _ := r.Seek(0, io.SeekCurrent)
+
+		if vintIsUnknown(elemSize, elemW) {
+			break
+		}
+
+		switch elemID {
+		case ebmlInfo:
+			webmParseInfo(r, dataPos, int64(elemSize), &tsScale, &infoDuration, &hasDuration)
+		case ebmlCluster:
+			if ts, err := webmClusterTS(r, dataPos, int64(elemSize)); err == nil {
+				lastClusterTS = int64(ts)
+			}
+		}
+
+		if _, err := r.Seek(dataPos+int64(elemSize), io.SeekStart); err != nil {
+			break
+		}
+	}
+
+	if hasDuration && infoDuration > 0 {
+		return &MediaInfo{
+			Duration: infoDuration * float64(tsScale) / 1e9,
+			Format:   "webm",
+		}, nil
+	}
+	if lastClusterTS >= 0 {
+		return &MediaInfo{
+			Duration: float64(lastClusterTS) * float64(tsScale) / 1e9,
+			Format:   "webm",
+		}, nil
+	}
+	return &MediaInfo{Format: "webm"}, nil
+}
+
+func webmParseInfo(r io.ReadSeeker, start, size int64, tsScale *uint64, dur *float64, hasDur *bool) {
+	r.Seek(start, io.SeekStart)
+	end := start + size
+
+	for {
+		pos, _ := r.Seek(0, io.SeekCurrent)
+		if pos >= end {
+			return
+		}
+		childID, _, err := readVINT(r, true)
+		if err != nil {
+			return
+		}
+		childSize, _, err := readVINT(r, false)
+		if err != nil {
+			return
+		}
+
+		switch childID {
+		case ebmlTSScale:
+			if childSize <= 8 {
+				if v, err := ebmlReadUint(r, int(childSize)); err == nil {
+					*tsScale = v
+				}
+			}
+		case ebmlDuration:
+			switch childSize {
+			case 4:
+				var buf [4]byte
+				if _, err := io.ReadFull(r, buf[:]); err == nil {
+					*dur = float64(math.Float32frombits(binary.BigEndian.Uint32(buf[:])))
+					*hasDur = true
+				}
+			case 8:
+				var buf [8]byte
+				if _, err := io.ReadFull(r, buf[:]); err == nil {
+					*dur = math.Float64frombits(binary.BigEndian.Uint64(buf[:]))
+					*hasDur = true
+				}
+			default:
+				r.Seek(int64(childSize), io.SeekCurrent)
+			}
+		default:
+			r.Seek(int64(childSize), io.SeekCurrent)
+		}
+	}
+}
+
+// webmClusterTS reads the Timestamp child from a Cluster element.
+func webmClusterTS(r io.ReadSeeker, start, size int64) (uint64, error) {
+	r.Seek(start, io.SeekStart)
+	end := start + size
+
+	for i := 0; i < 8; i++ {
+		pos, _ := r.Seek(0, io.SeekCurrent)
+		if pos >= end {
+			break
+		}
+		childID, _, err := readVINT(r, true)
+		if err != nil {
+			break
+		}
+		childSize, _, err := readVINT(r, false)
+		if err != nil {
+			break
+		}
+		if childID == ebmlTimestamp && childSize <= 8 {
+			return ebmlReadUint(r, int(childSize))
+		}
+		r.Seek(int64(childSize), io.SeekCurrent)
+	}
+	return 0, fmt.Errorf("no timestamp")
+}

--- a/mediaprobe/webm_test.go
+++ b/mediaprobe/webm_test.go
@@ -1,0 +1,235 @@
+package mediaprobe
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"testing"
+)
+
+func appendVINTID(buf *bytes.Buffer, id uint64) {
+	switch {
+	case id <= 0xFF:
+		buf.WriteByte(byte(id))
+	case id <= 0xFFFF:
+		buf.WriteByte(byte(id >> 8))
+		buf.WriteByte(byte(id))
+	case id <= 0xFFFFFF:
+		buf.WriteByte(byte(id >> 16))
+		buf.WriteByte(byte(id >> 8))
+		buf.WriteByte(byte(id))
+	default:
+		buf.WriteByte(byte(id >> 24))
+		buf.WriteByte(byte(id >> 16))
+		buf.WriteByte(byte(id >> 8))
+		buf.WriteByte(byte(id))
+	}
+}
+
+func appendVINTSize(buf *bytes.Buffer, size int) {
+	if size < 0x80 {
+		buf.WriteByte(byte(0x80 | size))
+	} else if size < 0x4000 {
+		buf.WriteByte(byte(0x40 | (size >> 8)))
+		buf.WriteByte(byte(size))
+	} else {
+		buf.WriteByte(byte(0x20 | (size >> 16)))
+		buf.WriteByte(byte(size >> 8))
+		buf.WriteByte(byte(size))
+	}
+}
+
+func buildWebMWithDuration(durationMS float64) []byte {
+	var b bytes.Buffer
+
+	// EBML Header
+	appendVINTID(&b, ebmlHeaderID)
+	appendVINTSize(&b, 5)
+	b.Write(make([]byte, 5))
+
+	// Segment (unknown size)
+	appendVINTID(&b, ebmlSegment)
+	b.Write([]byte{0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF})
+
+	// Info element
+	var info bytes.Buffer
+	appendVINTID(&info, ebmlTSScale)
+	appendVINTSize(&info, 3)
+	info.Write([]byte{0x0F, 0x42, 0x40}) // 1000000
+
+	appendVINTID(&info, ebmlDuration)
+	appendVINTSize(&info, 8)
+	var dur [8]byte
+	binary.BigEndian.PutUint64(dur[:], math.Float64bits(durationMS))
+	info.Write(dur[:])
+
+	appendVINTID(&b, ebmlInfo)
+	appendVINTSize(&b, info.Len())
+	b.Write(info.Bytes())
+
+	return b.Bytes()
+}
+
+func buildWebMWithClusters(timestampsMS []uint64) []byte {
+	var b bytes.Buffer
+
+	appendVINTID(&b, ebmlHeaderID)
+	appendVINTSize(&b, 5)
+	b.Write(make([]byte, 5))
+
+	appendVINTID(&b, ebmlSegment)
+	b.Write([]byte{0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF})
+
+	// Info (no Duration)
+	var info bytes.Buffer
+	appendVINTID(&info, ebmlTSScale)
+	appendVINTSize(&info, 3)
+	info.Write([]byte{0x0F, 0x42, 0x40})
+	appendVINTID(&b, ebmlInfo)
+	appendVINTSize(&b, info.Len())
+	b.Write(info.Bytes())
+
+	for _, ts := range timestampsMS {
+		var cluster bytes.Buffer
+		appendVINTID(&cluster, ebmlTimestamp)
+		if ts <= 0xFF {
+			appendVINTSize(&cluster, 1)
+			cluster.WriteByte(byte(ts))
+		} else if ts <= 0xFFFF {
+			appendVINTSize(&cluster, 2)
+			cluster.WriteByte(byte(ts >> 8))
+			cluster.WriteByte(byte(ts))
+		} else {
+			appendVINTSize(&cluster, 3)
+			cluster.WriteByte(byte(ts >> 16))
+			cluster.WriteByte(byte(ts >> 8))
+			cluster.WriteByte(byte(ts))
+		}
+
+		appendVINTID(&b, ebmlCluster)
+		appendVINTSize(&b, cluster.Len())
+		b.Write(cluster.Bytes())
+	}
+
+	return b.Bytes()
+}
+
+func TestProbeWebM_Duration(t *testing.T) {
+	data := buildWebMWithDuration(5123.0) // 5123 ms
+	r := bytes.NewReader(data)
+
+	info, err := probeWebM(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Format != "webm" {
+		t.Errorf("format = %q, want webm", info.Format)
+	}
+	// 5123ms * 1000000ns/ms / 1e9 = 5.123s
+	want := 5.123
+	if math.Abs(info.Duration-want) > 0.001 {
+		t.Errorf("duration = %v, want %v", info.Duration, want)
+	}
+}
+
+func TestProbeWebM_Float32Duration(t *testing.T) {
+	var b bytes.Buffer
+
+	appendVINTID(&b, ebmlHeaderID)
+	appendVINTSize(&b, 5)
+	b.Write(make([]byte, 5))
+
+	appendVINTID(&b, ebmlSegment)
+	b.Write([]byte{0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF})
+
+	var info bytes.Buffer
+	appendVINTID(&info, ebmlTSScale)
+	appendVINTSize(&info, 3)
+	info.Write([]byte{0x0F, 0x42, 0x40})
+
+	appendVINTID(&info, ebmlDuration)
+	appendVINTSize(&info, 4)
+	var dur [4]byte
+	binary.BigEndian.PutUint32(dur[:], math.Float32bits(3000.0))
+	info.Write(dur[:])
+
+	appendVINTID(&b, ebmlInfo)
+	appendVINTSize(&b, info.Len())
+	b.Write(info.Bytes())
+
+	mi, err := probeWebM(bytes.NewReader(b.Bytes()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := 3.0
+	if math.Abs(mi.Duration-want) > 0.001 {
+		t.Errorf("duration = %v, want %v", mi.Duration, want)
+	}
+}
+
+func TestProbeWebM_ClusterFallback(t *testing.T) {
+	data := buildWebMWithClusters([]uint64{0, 500, 1000, 3500})
+	r := bytes.NewReader(data)
+
+	info, err := probeWebM(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Last cluster at 3500ms → 3.5s
+	want := 3.5
+	if math.Abs(info.Duration-want) > 0.001 {
+		t.Errorf("duration = %v, want %v", info.Duration, want)
+	}
+}
+
+func TestProbeWebM_EmptyFile(t *testing.T) {
+	_, err := probeWebM(bytes.NewReader(nil))
+	if err == nil {
+		t.Error("expected error for empty file")
+	}
+}
+
+func TestProbeWebM_BadMagic(t *testing.T) {
+	_, err := probeWebM(bytes.NewReader([]byte{0x00, 0x00, 0x00, 0x00}))
+	if err == nil {
+		t.Error("expected error for bad magic")
+	}
+}
+
+func TestDetectFormat_WebM(t *testing.T) {
+	data := buildWebMWithDuration(1000)
+	r := bytes.NewReader(data)
+	fmt := detectFormat(r, "")
+	if fmt != "webm" {
+		t.Errorf("detectFormat = %q, want webm", fmt)
+	}
+}
+
+func TestNormalizeHint_WebM(t *testing.T) {
+	cases := map[string]string{
+		"webm":       "webm",
+		"audio/webm": "webm",
+		"video/webm": "webm",
+	}
+	for hint, want := range cases {
+		if got := normalizeHint(hint); got != want {
+			t.Errorf("normalizeHint(%q) = %q, want %q", hint, got, want)
+		}
+	}
+}
+
+func TestProbeReader_WebM(t *testing.T) {
+	data := buildWebMWithDuration(2500)
+	info, err := ProbeReader(bytes.NewReader(data), "webm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Format != "webm" {
+		t.Errorf("format = %q, want webm", info.Format)
+	}
+	want := 2.5
+	if math.Abs(info.Duration-want) > 0.001 {
+		t.Errorf("duration = %v, want %v", info.Duration, want)
+	}
+}


### PR DESCRIPTION
…d duration calculations

- Added support for new MP4 atoms: mvex, moof, traf.
- Implemented parsing functions for mdhd, trex, tfhd, and trun to extract relevant metadata.
- Updated duration calculation logic to utilize fragment duration sums and timescale from mdhd.
- Enhanced format detection to include webm support in probe and normalize hint functions.

These changes improve the handling of MP4 files and extend the capabilities of the media probing functionality.