### PR TITLE
feat(store): implement FreshReader interface and GetFresh method for …

### DIFF
--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1286,3 +1286,107 @@ func BenchmarkMongoConcurrentWrite(b *testing.B) {
 	store := newStore(&testing.T{}, getConnector(&testing.T{}, "mongo"))
 	benchmarkConcurrentWrite(b, store)
 }
+
+// TestXunGetFresh verifies that GetFresh bypasses the ARC cache and reads
+// directly from the database, then updates the cache.
+func TestXunGetFresh(t *testing.T) {
+	kv := newXunStore(t)
+
+	fr, ok := kv.(FreshReader)
+	if !ok {
+		t.Fatal("xun store does not implement FreshReader")
+	}
+
+	kv.Clear()
+
+	// Write data and flush to DB
+	kv.Set("fresh_key", "fresh_value", 0)
+	kv.Flush()
+
+	// GetFresh should return the value from DB
+	val, ok := fr.GetFresh("fresh_key")
+	assert.True(t, ok)
+	assert.Equal(t, "fresh_value", val)
+
+	// Overwrite via Set (updates ARC cache + dirty queue)
+	kv.Set("fresh_key", "updated_value", 0)
+	kv.Flush()
+
+	// Regular Get returns updated value from ARC cache
+	val, ok = kv.Get("fresh_key")
+	assert.True(t, ok)
+	assert.Equal(t, "updated_value", val)
+
+	// GetFresh also returns updated value (from DB, bypassing ARC)
+	val, ok = fr.GetFresh("fresh_key")
+	assert.True(t, ok)
+	assert.Equal(t, "updated_value", val)
+
+	// Non-existent key
+	_, ok = fr.GetFresh("nonexistent")
+	assert.False(t, ok)
+
+	// Deleted key: delete and flush, then GetFresh should not find it
+	kv.Del("fresh_key")
+	kv.Flush()
+	_, ok = fr.GetFresh("fresh_key")
+	assert.False(t, ok)
+}
+
+// TestXunGetFreshBypassesCache verifies GetFresh reads from DB even when
+// the ARC cache holds stale data, simulating a cross-process write.
+func TestXunGetFreshBypassesCache(t *testing.T) {
+	kv := newXunStore(t)
+
+	fr, ok := kv.(FreshReader)
+	if !ok {
+		t.Fatal("xun store does not implement FreshReader")
+	}
+
+	kv.Clear()
+
+	// Write "v1" and flush to DB
+	kv.Set("bypass_key", "v1", 0)
+	kv.Flush()
+
+	// Regular Get populates ARC cache with "v1"
+	val, ok := kv.Get("bypass_key")
+	assert.True(t, ok)
+	assert.Equal(t, "v1", val)
+
+	// Simulate cross-process write: update the DB row directly without
+	// touching the ARC cache. We do this by writing "v2" + flush, then
+	// restoring "v1" in the ARC cache via a second Set + immediate Get
+	// that re-populates the cache, then writing "v2" to DB only.
+
+	// Simpler approach: write v2, flush to DB, then overwrite ARC with v1
+	kv.Set("bypass_key", "v2", 0)
+	kv.Flush()
+
+	// Force ARC cache to hold stale value "v1" by writing then reading
+	kv.Set("bypass_key", "v1_stale", 0)
+	// ARC cache now has "v1_stale", but DB has "v2" (not yet flushed)
+
+	// Regular Get returns stale ARC value
+	val, ok = kv.Get("bypass_key")
+	assert.True(t, ok)
+	assert.Equal(t, "v1_stale", val)
+
+	// GetFresh bypasses ARC and reads "v2" from DB
+	val, ok = fr.GetFresh("bypass_key")
+	assert.True(t, ok)
+	assert.Equal(t, "v2", val, "GetFresh should return DB value, not stale ARC cache")
+
+	// After GetFresh, ARC cache is updated — regular Get now returns "v2"
+	val, ok = kv.Get("bypass_key")
+	assert.True(t, ok)
+	assert.Equal(t, "v2", val, "ARC cache should be refreshed after GetFresh")
+}
+
+// TestLRUNotFreshReader verifies that the LRU store does not implement
+// FreshReader (it has no backing store to read from).
+func TestLRUNotFreshReader(t *testing.T) {
+	kv := newStore(t, nil)
+	_, ok := kv.(FreshReader)
+	assert.False(t, ok, "LRU store should not implement FreshReader")
+}

--- a/store/types.go
+++ b/store/types.go
@@ -45,6 +45,15 @@ type Store interface {
 	Flush()
 }
 
+// FreshReader is an optional interface for stores with internal caching.
+// GetFresh bypasses the in-process cache and reads directly from the
+// backing store (e.g. database), then updates the cache with fresh data.
+// Stores without internal caching (redis, mongo) do not need this;
+// their Get already reads from the external store.
+type FreshReader interface {
+	GetFresh(key string) (value interface{}, ok bool)
+}
+
 // Instance the kv-store setting
 type Instance struct {
 	types.MetaInfo

--- a/store/xun/xun.go
+++ b/store/xun/xun.go
@@ -318,6 +318,72 @@ func (store *Store) unprefixKey(key string) string {
 	return strings.TrimPrefix(key, store.prefix)
 }
 
+// GetFresh reads directly from the database, bypassing the ARC cache.
+// The ARC cache is updated with the fresh value on success.
+// Keys pending async deletion in this process are still excluded.
+// Use when cached data may be stale due to cross-process writes.
+func (store *Store) GetFresh(key string) (value interface{}, ok bool) {
+	prefixedKey := store.prefixKey(key)
+
+	// Respect pending deletions from this process
+	store.deletedMu.RLock()
+	isDeleted := store.deleted[prefixedKey]
+	store.deletedMu.RUnlock()
+	if isDeleted {
+		return nil, false
+	}
+
+	row, err := capsule.Query().
+		Table(store.tableName).
+		Where("key", prefixedKey).
+		Where(func(qb query.Query) {
+			qb.WhereNull("expired_at").OrWhere("expired_at", ">", time.Now())
+		}).
+		First()
+
+	if err != nil {
+		if !strings.Contains(err.Error(), "no rows") {
+			log.Error("Store xun GetFresh %s: %s", prefixedKey, err.Error())
+		}
+		return nil, false
+	}
+
+	if row.IsEmpty() {
+		return nil, false
+	}
+
+	valueStr, ok := row.Get("value").(string)
+	if !ok {
+		return nil, false
+	}
+
+	var result interface{}
+	if err := jsoniter.UnmarshalFromString(valueStr, &result); err != nil {
+		log.Error("Store xun GetFresh unmarshal %s: %s", prefixedKey, err.Error())
+		return nil, false
+	}
+
+	typ := "value"
+	if t, ok := row.Get("type").(string); ok {
+		typ = t
+	}
+
+	var expiredAt *time.Time
+	if exp := row.Get("expired_at"); exp != nil {
+		if t, ok := exp.(time.Time); ok {
+			expiredAt = &t
+		}
+	}
+
+	store.cache.Add(prefixedKey, &cacheEntry{
+		Value:     result,
+		ExpiredAt: expiredAt,
+		Type:      typ,
+	})
+
+	return result, true
+}
+
 // Get looks up a key's value from the store (cache-first, lazy load from DB)
 func (store *Store) Get(key string) (value interface{}, ok bool) {
 	prefixedKey := store.prefixKey(key)


### PR DESCRIPTION
…direct DB access

- Added FreshReader interface to allow stores with internal caching to bypass the cache and read directly from the database.
- Implemented GetFresh method in the xun store to retrieve fresh data from the database while updating the cache.
- Added unit tests for GetFresh functionality, ensuring it handles cache bypassing and stale data correctly.

These changes enhance data retrieval accuracy in scenarios where cached data may be outdated due to cross-process writes.