### PR TITLE
feat(llm): add OCR support to Capabilities struct and related tests

### DIFF
--- a/connector/openai/defaults.go
+++ b/connector/openai/defaults.go
@@ -225,6 +225,16 @@ var DefaultModelCapabilities = map[string]Capabilities{
 		JSON:       true,
 		Multimodal: false,
 	},
+	"qwen3.5-ocr": {
+		Vision:    "openai",
+		OCR:       true,
+		Streaming: true,
+	},
+	"qwen-vl-ocr": {
+		Vision:    "openai",
+		OCR:       true,
+		Streaming: true,
+	},
 
 	// ByteDance Models (Index: 57)
 	"doubao-seed": {

--- a/connector/openai/defaults_test.go
+++ b/connector/openai/defaults_test.go
@@ -1,0 +1,56 @@
+package openai
+
+import "testing"
+
+func TestGetDefaultCapabilities_OCRModels(t *testing.T) {
+	tests := []struct {
+		model   string
+		wantOCR bool
+		wantVis bool
+	}{
+		{"qwen3.5-ocr", true, true},
+		{"Qwen3.5-OCR", true, true},
+		{"qwen-vl-ocr", true, true},
+		{"qwen-vl-ocr-latest", true, true},
+	}
+	for _, tt := range tests {
+		caps := GetDefaultCapabilities(tt.model)
+		if caps == nil {
+			t.Errorf("GetDefaultCapabilities(%q) = nil, want match", tt.model)
+			continue
+		}
+		if caps.OCR != tt.wantOCR {
+			t.Errorf("GetDefaultCapabilities(%q).OCR = %v, want %v", tt.model, caps.OCR, tt.wantOCR)
+		}
+		if caps.HasVision() != tt.wantVis {
+			t.Errorf("GetDefaultCapabilities(%q).HasVision() = %v, want %v", tt.model, caps.HasVision(), tt.wantVis)
+		}
+	}
+}
+
+func TestGetDefaultCapabilities_NonOCRModels(t *testing.T) {
+	nonOCR := []string{"gpt-5", "deepseek-chat", "qwen3-max", "claude-4.5-sonnet"}
+	for _, model := range nonOCR {
+		caps := GetDefaultCapabilities(model)
+		if caps == nil {
+			continue
+		}
+		if caps.OCR {
+			t.Errorf("GetDefaultCapabilities(%q).OCR = true, non-OCR model should be false", model)
+		}
+	}
+}
+
+func TestGetDefaultCapabilities_NoMatch(t *testing.T) {
+	caps := GetDefaultCapabilities("totally-unknown-model-xyz")
+	if caps != nil {
+		t.Error("unknown model should return nil")
+	}
+}
+
+func TestGetDefaultCapabilities_Empty(t *testing.T) {
+	caps := GetDefaultCapabilities("")
+	if caps != nil {
+		t.Error("empty model should return nil")
+	}
+}

--- a/llm/capabilities.go
+++ b/llm/capabilities.go
@@ -15,6 +15,7 @@ type Capabilities struct {
 	Embedding             bool        `json:"embedding,omitempty" yaml:"embedding,omitempty"`                           // Text embedding model (e.g. text-embedding-3-large)
 	ImageGeneration       bool        `json:"image_generation,omitempty" yaml:"image_generation,omitempty"`             // Image generation model (e.g. DALL-E, Seedream)
 	ImageEditing          interface{} `json:"image_editing,omitempty" yaml:"image_editing,omitempty"`                   // Image editing: bool or protocol string ("multipart" = form-data /images/edits, "json" = JSON /images/generations + image field)
+	OCR                   bool        `json:"ocr,omitempty" yaml:"ocr,omitempty"`                                       // OCR text extraction model (e.g. Qwen3.5-OCR, Qwen-VL-OCR)
 	TemperatureAdjustable bool        `json:"temperature_adjustable,omitempty" yaml:"temperature_adjustable,omitempty"` // Supports temperature adjustment (reasoning models typically don't)
 	MaxInputTokens        int         `json:"max_input_tokens,omitempty" yaml:"max_input_tokens,omitempty"`             // Maximum input context window size (aligned with Anthropic Models API)
 	MaxOutputTokens       int         `json:"max_output_tokens,omitempty" yaml:"max_output_tokens,omitempty"`           // Maximum output tokens the model can generate
@@ -62,6 +63,11 @@ func (c *Capabilities) HasImageEditing() bool {
 	}
 }
 
+// HasOCR reports whether the model supports OCR text extraction.
+func (c *Capabilities) HasOCR() bool {
+	return c != nil && c.OCR
+}
+
 // GetImageEditingFormat returns the image editing API protocol.
 // Returns "multipart" or "json" when explicitly set, empty string otherwise.
 // Callers should treat empty as "json" (the most common default).
@@ -97,6 +103,7 @@ func (c *Capabilities) ToMap() map[string]interface{} {
 	if c.ImageEditing != nil {
 		result["image_editing"] = c.ImageEditing
 	}
+	result["ocr"] = c.OCR
 	result["temperature_adjustable"] = c.TemperatureAdjustable
 	return result
 }

--- a/llm/capabilities_test.go
+++ b/llm/capabilities_test.go
@@ -98,6 +98,65 @@ func TestHasImageEditing_String(t *testing.T) {
 	}
 }
 
+func TestHasOCR(t *testing.T) {
+	var c *Capabilities
+	if c.HasOCR() {
+		t.Error("nil receiver should return false")
+	}
+	c = &Capabilities{OCR: false}
+	if c.HasOCR() {
+		t.Error("OCR=false should return false")
+	}
+	c.OCR = true
+	if !c.HasOCR() {
+		t.Error("OCR=true should return true")
+	}
+}
+
+func TestToMap_Nil(t *testing.T) {
+	var c *Capabilities
+	if m := c.ToMap(); m != nil {
+		t.Error("nil receiver should return nil")
+	}
+}
+
+func TestToMap(t *testing.T) {
+	c := &Capabilities{
+		Vision:          "openai",
+		OCR:             true,
+		Streaming:       true,
+		ImageGeneration: true,
+		Embedding:       false,
+	}
+	m := c.ToMap()
+	if m == nil {
+		t.Fatal("ToMap should not return nil for non-nil receiver")
+	}
+
+	if v, ok := m["ocr"].(bool); !ok || !v {
+		t.Error("ToMap must include ocr=true")
+	}
+	if v, ok := m["vision"]; !ok || v != "openai" {
+		t.Error("ToMap must include vision=\"openai\"")
+	}
+	if v, ok := m["streaming"].(bool); !ok || !v {
+		t.Error("ToMap must include streaming=true")
+	}
+	if v, ok := m["image_generation"].(bool); !ok || !v {
+		t.Error("ToMap must include image_generation=true")
+	}
+	if v, ok := m["embedding"].(bool); !ok || v {
+		t.Error("ToMap must include embedding=false")
+	}
+
+	// Zero-value Capabilities: all bools should be present as false
+	zero := &Capabilities{}
+	zm := zero.ToMap()
+	if v, ok := zm["ocr"].(bool); !ok || v {
+		t.Error("zero Capabilities: ocr should be false")
+	}
+}
+
 func TestGetImageEditingFormat(t *testing.T) {
 	var c *Capabilities
 	if f := c.GetImageEditingFormat(); f != "" {


### PR DESCRIPTION
- Introduced OCR field to the Capabilities struct to indicate support for OCR text extraction.
- Implemented HasOCR method to check if OCR is supported by the model.
- Enhanced ToMap method to include OCR in the capabilities map.
- Added unit tests for OCR functionality, covering various scenarios including nil values and different states of the OCR field.

These changes improve the model's ability to handle OCR capabilities effectively.